### PR TITLE
Allow step implementations to return Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 
 
+## [0.11.0] · 2021-??-??
+[0.11.0]: /../../tree/v0.11.0
+
+[Diff](/../../compare/v0.10.2...v0.11.0) | [Milestone](/../../milestone/3)
+
+### Added
+
+- Ability for step functions to return `Result`. ([#151])
+
+[#151]: /../../pull/151
+
+
+
+
 ## [0.10.2] · 2021-11-03
 [0.10.2]: /../../tree/v0.10.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cucumber"
-version = "0.10.2"
+version = "0.11.0-dev"
 edition = "2021"
 rust-version = "1.56"
 description = """\
@@ -49,7 +49,7 @@ sealed = "0.3"
 structopt = "0.3.25"
 
 # "macros" feature dependencies
-cucumber-codegen = { version = "0.10.2", path = "./codegen", optional = true }
+cucumber-codegen = { version = "0.11.0-dev", path = "./codegen", optional = true }
 inventory = { version = "0.1.10", optional = true }
 
 [dev-dependencies]

--- a/book/src/Getting_Started.md
+++ b/book/src/Getting_Started.md
@@ -218,9 +218,7 @@ If you run the test now, you'll see that all steps are accounted for and the tes
 
 <script id="asciicast-fHuIXkWrIk1AOFFqF0MYmY0m0" src="https://asciinema.org/a/fHuIXkWrIk1AOFFqF0MYmY0m0.js" async data-autoplay="true" data-rows="16"></script>
 
-In addition to assertions, you can also return a `Result` from your step
-implemenation. Returning `Err` will cause the step to fail. This lets you use
-the `?` operator for more concise step implementations.
+In addition to assertions, you can also return a `Result<()>` from your step function. Returning `Err` will cause the step to fail. This lets you use the `?` operator for more concise step implementations just like in [unit tests](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html#tests-and-).
 
 If you want to be assured that your validation is indeed happening, you can change the assertion for the cat being hungry from `true` to `false` temporarily:
 ```rust,should_panic

--- a/book/src/Getting_Started.md
+++ b/book/src/Getting_Started.md
@@ -218,6 +218,10 @@ If you run the test now, you'll see that all steps are accounted for and the tes
 
 <script id="asciicast-fHuIXkWrIk1AOFFqF0MYmY0m0" src="https://asciinema.org/a/fHuIXkWrIk1AOFFqF0MYmY0m0.js" async data-autoplay="true" data-rows="16"></script>
 
+In addition to assertions, you can also return a `Result` from your step
+implemenation. Returning `Err` will cause the step to fail. This lets you use
+the `?` operator for more concise step implementations.
+
 If you want to be assured that your validation is indeed happening, you can change the assertion for the cat being hungry from `true` to `false` temporarily:
 ```rust,should_panic
 # use std::convert::Infallible;

--- a/book/tests/Cargo.toml
+++ b/book/tests/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-cucumber = { version = "0.10", path = "../.." }
+cucumber = { version = "0.11.0-dev", path = "../.." }
 futures = "0.3"
 skeptic = "0.13"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to `cucumber-codegen` crate will be documented in this 
 
 
 
+## [0.11.0] · 2021-??-??
+[0.11.0]: /../../tree/v0.11.0/codegen
+
+[Milestone](/../../milestone/3)
+
+### Added
+
+- Unwrapping `Result`s returned by step functions. ([#151])
+
+[#151]: /../../pull/151
+
+
+
+
 ## [0.10.2] · 2021-11-03
 [0.10.2]: /../../tree/v0.10.2/codegen
 

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -31,9 +31,9 @@ syn = { version = "1.0.74", features = ["derive", "extra-traits", "full"] }
 [dev-dependencies]
 async-trait = "0.1"
 cucumber = { path = "..", features = ["macros"] }
-tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "time"] }
 futures = "0.3.17"
 tempfile = "3.2"
+tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "time"] }
 
 [[test]]
 name = "example"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -32,6 +32,8 @@ syn = { version = "1.0.74", features = ["derive", "extra-traits", "full"] }
 async-trait = "0.1"
 cucumber = { path = "..", features = ["macros"] }
 tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "time"] }
+futures = "0.3.17"
+tempfile = "3.2"
 
 [[test]]
 name = "example"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cucumber-codegen"
-version = "0.10.2" # should be the same as main crate version
+version = "0.11.0-dev" # should be the same as main crate version
 edition = "2021"
 rust-version = "1.56"
 description = "Code generation for `cucumber` crate."

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -187,9 +187,10 @@ macro_rules! step_attribute {
         ///
         /// # Return Value
         ///
-        /// A function may return a Result. Returning Err will cause the step to
-        /// fail.
+        /// A function may return a [`Result`]`<(), Err>`. `Err` is expected to
+        /// implement [`Display`] and returning it will cause the step to fail.
         ///
+        /// [`Display`]: std::fmt::Display
         /// [`FromStr`]: std::str::FromStr
         /// [`gherkin::Step`]: https://bit.ly/3j42hcd
         /// [`World`]: https://bit.ly/3j0aWw7

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -185,6 +185,11 @@ macro_rules! step_attribute {
         /// # }
         /// ```
         ///
+        /// # Return Value
+        ///
+        /// A function may return a Result. Returning Err will cause the step to
+        /// fail.
+        ///
         /// [`FromStr`]: std::str::FromStr
         /// [`gherkin::Step`]: https://bit.ly/3j42hcd
         /// [`World`]: https://bit.ly/3j0aWw7

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -185,10 +185,11 @@ macro_rules! step_attribute {
         /// # }
         /// ```
         ///
-        /// # Return Value
+        /// # Return value
         ///
-        /// A function may return a [`Result`]`<(), Err>`. `Err` is expected to
-        /// implement [`Display`] and returning it will cause the step to fail.
+        /// A function may also return a [`Result`], which [`Err`] is expected
+        /// to implement [`Display`], so returning it will cause the step to
+        /// fail.
         ///
         /// [`Display`]: std::fmt::Display
         /// [`FromStr`]: std::str::FromStr

--- a/codegen/tests/example.rs
+++ b/codegen/tests/example.rs
@@ -64,7 +64,7 @@ fn test_regex_sync_slice(w: &mut MyWorld, step: &Step, matches: &[String]) {
     w.foo += 1;
 }
 
-#[when(regex = r#"^I write "(\S+)" to `(\S+)`$"#)]
+#[when(regex = r#"^I write "(\S+)" to `([^`\s]+)`$"#)]
 fn test_return_result_write(
     w: &mut MyWorld,
     what: String,
@@ -75,7 +75,7 @@ fn test_return_result_write(
     fs::write(path, what)
 }
 
-#[then(regex = r#"^the file `(\S+)` should contain "(\S+)"$"#)]
+#[then(regex = r#"^the file `([^`\s]+)` should contain "(\S+)"$"#)]
 fn test_return_result_read(
     w: &mut MyWorld,
     filename: String,

--- a/codegen/tests/example.rs
+++ b/codegen/tests/example.rs
@@ -1,20 +1,26 @@
-use std::{convert::Infallible, time::Duration};
+use std::{fs, io, panic::AssertUnwindSafe, time::Duration};
 
 use async_trait::async_trait;
-use cucumber::{gherkin::Step, given, when, World, WorldInit};
+use cucumber::{gherkin::Step, given, then, when, World, WorldInit};
+use futures::FutureExt;
+use tempfile::TempDir;
 use tokio::time;
 
 #[derive(Debug, WorldInit)]
 pub struct MyWorld {
     foo: i32,
+    working: TempDir,
 }
 
 #[async_trait(?Send)]
 impl World for MyWorld {
-    type Error = Infallible;
+    type Error = io::Error;
 
     async fn new() -> Result<Self, Self::Error> {
-        Ok(Self { foo: 0 })
+        Ok(Self {
+            foo: 0,
+            working: TempDir::new()?,
+        })
     }
 }
 
@@ -58,11 +64,41 @@ fn test_regex_sync_slice(w: &mut MyWorld, step: &Step, matches: &[String]) {
     w.foo += 1;
 }
 
+#[when(regex = r#"I write "(\S+?)" to "(\S+?)""#)]
+fn test_return_result_write(
+    w: &mut MyWorld,
+    what: String,
+    filename: String,
+) -> io::Result<()> {
+    let mut path = w.working.path().to_path_buf();
+    path.push(filename);
+    fs::write(path, what)
+}
+
+#[then(regex = r#"the file "(\S+?)" should contain "(\S+?)""#)]
+fn test_return_result_read(
+    w: &mut MyWorld,
+    filename: String,
+    what: String,
+) -> io::Result<()> {
+    let mut path = w.working.path().to_path_buf();
+    path.push(filename);
+    assert_eq!(what, fs::read_to_string(path)?);
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() {
-    MyWorld::cucumber()
+    let res = MyWorld::cucumber()
         .max_concurrent_scenarios(None)
         .fail_on_skipped()
-        .run_and_exit("./tests/features")
-        .await;
+        .run_and_exit("./tests/features");
+
+    let err = AssertUnwindSafe(res)
+        .catch_unwind()
+        .await
+        .expect_err("should err");
+    let err = err.downcast_ref::<String>().unwrap();
+
+    assert_eq!(err, "1 step failed");
 }

--- a/codegen/tests/example.rs
+++ b/codegen/tests/example.rs
@@ -2,7 +2,7 @@ use std::{fs, io, panic::AssertUnwindSafe, time::Duration};
 
 use async_trait::async_trait;
 use cucumber::{gherkin::Step, given, then, when, World, WorldInit};
-use futures::FutureExt;
+use futures::FutureExt as _;
 use tempfile::TempDir;
 use tokio::time;
 
@@ -64,7 +64,7 @@ fn test_regex_sync_slice(w: &mut MyWorld, step: &Step, matches: &[String]) {
     w.foo += 1;
 }
 
-#[when(regex = r#"I write "(\S+?)" to "(\S+?)""#)]
+#[when(regex = r#"^I write "(\S+)" to `(\S+)`$"#)]
 fn test_return_result_write(
     w: &mut MyWorld,
     what: String,
@@ -75,7 +75,7 @@ fn test_return_result_write(
     fs::write(path, what)
 }
 
-#[then(regex = r#"the file "(\S+?)" should contain "(\S+?)""#)]
+#[then(regex = r#"^the file `(\S+)` should contain "(\S+)"$"#)]
 fn test_return_result_read(
     w: &mut MyWorld,
     filename: String,
@@ -83,7 +83,9 @@ fn test_return_result_read(
 ) -> io::Result<()> {
     let mut path = w.dir.path().to_path_buf();
     path.push(filename);
+
     assert_eq!(what, fs::read_to_string(path)?);
+
     Ok(())
 }
 

--- a/codegen/tests/example.rs
+++ b/codegen/tests/example.rs
@@ -9,7 +9,7 @@ use tokio::time;
 #[derive(Debug, WorldInit)]
 pub struct MyWorld {
     foo: i32,
-    working: TempDir,
+    dir: TempDir,
 }
 
 #[async_trait(?Send)]
@@ -19,7 +19,7 @@ impl World for MyWorld {
     async fn new() -> Result<Self, Self::Error> {
         Ok(Self {
             foo: 0,
-            working: TempDir::new()?,
+            dir: TempDir::new()?,
         })
     }
 }
@@ -70,7 +70,7 @@ fn test_return_result_write(
     what: String,
     filename: String,
 ) -> io::Result<()> {
-    let mut path = w.working.path().to_path_buf();
+    let mut path = w.dir.path().to_path_buf();
     path.push(filename);
     fs::write(path, what)
 }
@@ -81,7 +81,7 @@ fn test_return_result_read(
     filename: String,
     what: String,
 ) -> io::Result<()> {
-    let mut path = w.working.path().to_path_buf();
+    let mut path = w.dir.path().to_path_buf();
     path.push(filename);
     assert_eq!(what, fs::read_to_string(path)?);
     Ok(())

--- a/codegen/tests/features/example.feature
+++ b/codegen/tests/features/example.feature
@@ -14,3 +14,11 @@ Feature: Example feature
 
   Scenario: An example sync scenario
     Given foo is sync 0
+
+  Scenario: Steps that return results
+    When I write "abc" to "myfile"
+    Then the file "myfile" should contain "abc"
+
+  Scenario: Steps that return results and fail
+    When I write "abc" to "myfile"
+    Then the file "not-here" should contain "abc"

--- a/codegen/tests/features/example.feature
+++ b/codegen/tests/features/example.feature
@@ -15,10 +15,10 @@ Feature: Example feature
   Scenario: An example sync scenario
     Given foo is sync 0
 
-  Scenario: Steps that return results
-    When I write "abc" to "myfile"
-    Then the file "myfile" should contain "abc"
+  Scenario: Steps returning result
+    When I write "abc" to `myfile.txt`
+    Then the file `myfile.txt` should contain "abc"
 
-  Scenario: Steps that return results and fail
-    When I write "abc" to "myfile"
-    Then the file "not-here" should contain "abc"
+  Scenario: Steps returning result and failing
+    When I write "abc" to `myfile.txt`
+    Then the file `not-here.txt` should contain "abc"

--- a/codegen/tests/two_worlds.rs
+++ b/codegen/tests/two_worlds.rs
@@ -66,7 +66,7 @@ async fn main() {
         .await;
 
     assert_eq!(writer.steps.passed, 7);
-    assert_eq!(writer.steps.skipped, 2);
+    assert_eq!(writer.steps.skipped, 4);
     assert_eq!(writer.steps.failed, 0);
 
     let writer = SecondWorld::cucumber()
@@ -75,6 +75,6 @@ async fn main() {
         .await;
 
     assert_eq!(writer.steps.passed, 1);
-    assert_eq!(writer.steps.skipped, 5);
+    assert_eq!(writer.steps.skipped, 7);
     assert_eq!(writer.steps.failed, 0);
 }


### PR DESCRIPTION
Allows step implementations to optionally return a Result. This would be a nice-to-have feature, whose main purpose is to allow writing more concise implementations using the `?` operator.