### PR TITLE
Implement `writer::Json` (#127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: ["<none>", "macros", "timestamps", "output-junit"]
+        feature: ["<none>", "macros", "timestamps", "output-json", "output-junit"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: ["<none>", "macros", "timestamps", "output-json", "output-junit"]
+        feature:
+          - <none>
+          - macros
+          - timestamps
+          - output-json
+          - output-junit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 - Ability for step functions to return `Result`. ([#151])
 - Arbitrary output for `writer::Basic` ([#147])
 - `writer::JUnit` ([JUnit XML report][0110-1]) behind the `output-junit` feature flag ([#147])
+- `writer::Json` ([Json schema][0110-2]) behind the `output-json` feature flag ([#159])
 
 [#147]: /../../pull/147
 [#151]: /../../pull/151
+[#159]: /../../pull/159
 [0110-1]: https://llg.cubic.org/docs/junit
+[0110-2]: https://github.com/cucumber/cucumber-json-schema
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 ### Added
 
 - Ability for step functions to return `Result`. ([#151])
-- Arbitrary output for `writer::Basic` ([#147])
-- `writer::JUnit` ([JUnit XML report][0110-1]) behind the `output-junit` feature flag ([#147])
-- `writer::Json` ([Json schema][0110-2]) behind the `output-json` feature flag ([#159])
+- Arbitrary output for `writer::Basic`. ([#147])
+- `writer::JUnit` ([JUnit XML report][0110-1]) behind the `output-junit` feature flag. ([#147])
+- `writer::Json` ([Cucumber JSON format][0110-2]) behind the `output-json` feature flag. ([#159])
 
 [#147]: /../../pull/147
 [#151]: /../../pull/151

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ cucumber-codegen = { version = "0.11.0-dev", path = "./codegen", optional = true
 inventory = { version = "0.1.10", optional = true }
 
 # "output-json" feature dependencies
-serde = { version = "1.0", features = ["derive"], optional = true }
-serde_json = { version = "1.0", optional = true }
+serde = { version = "1.0.60", features = ["derive"], optional = true }
+serde_json = { version = "1.0.18", optional = true }
 Inflector = { version = "0.11", default-features = false, optional = true }
 
 # "output-junit" feature dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ cucumber-codegen = { version = "0.11.0-dev", path = "./codegen", optional = true
 inventory = { version = "0.1.10", optional = true }
 
 # "output-json" feature dependencies
-serde = { version = "1.0.60", features = ["derive"], optional = true }
+serde = { version = "1.0.103", features = ["derive"], optional = true }
 serde_json = { version = "1.0.18", optional = true }
 Inflector = { version = "0.11", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/cucumber-rs/cucumber"
 readme = "README.md"
 categories = ["asynchronous", "development-tools::testing"]
 keywords = ["cucumber", "testing", "bdd", "atdd", "async"]
-include = ["/src/", "/tests/junit.rs", "/tests/wait.rs", "/LICENSE-*", "/README.md", "/CHANGELOG.md"]
+include = ["/src/", "/tests/json.rs", "/tests/junit.rs", "/tests/wait.rs", "/LICENSE-*", "/README.md", "/CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -29,7 +29,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["macros"]
 # Enables step attributes and auto-wiring.
 macros = ["cucumber-codegen", "inventory"]
-# Enables support for outputting JSON schema report.
+# Enables support for outputting JSON schema.
 output-json = ["Inflector", "serde", "serde_json", "timestamps"]
 # Enables support for outputting JUnit XML report.
 output-junit = ["junit-report", "timestamps"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["macros"]
 # Enables step attributes and auto-wiring.
 macros = ["cucumber-codegen", "inventory"]
-# Enables support for outputting JSON schema.
+# Enables support for outputting in Cucumber JSON format.
 output-json = ["Inflector", "serde", "serde_json", "timestamps"]
 # Enables support for outputting JUnit XML report.
 output-junit = ["junit-report", "timestamps"]
@@ -57,9 +57,9 @@ cucumber-codegen = { version = "0.11.0-dev", path = "./codegen", optional = true
 inventory = { version = "0.1.10", optional = true }
 
 # "output-json" feature dependencies
-serde = { version = "1.0.130", features = ["derive"], optional = true }
-serde_json = { version = "1.0.69", optional = true }
-Inflector = { version = "0.11.4", default-features = false, optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
+Inflector = { version = "0.11", default-features = false, optional = true }
 
 # "output-junit" feature dependencies
 junit-report = { version = "0.7", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["macros"]
 # Enables step attributes and auto-wiring.
 macros = ["cucumber-codegen", "inventory"]
+# Enables support for outputting JSON schema report.
+output-json = ["Inflector", "serde", "serde_json", "timestamps"]
 # Enables support for outputting JUnit XML report.
 output-junit = ["junit-report", "timestamps"]
 # Enables timestamps collecting for all events.
@@ -54,6 +56,11 @@ structopt = "0.3.25"
 cucumber-codegen = { version = "0.11.0-dev", path = "./codegen", optional = true }
 inventory = { version = "0.1.10", optional = true }
 
+# "output-json" feature dependencies
+serde = { version = "1.0.130", features = ["derive"], optional = true }
+serde_json = { version = "1.0.69", optional = true }
+Inflector = { version = "0.11.4", default-features = false, optional = true }
+
 # "output-junit" feature dependencies
 junit-report = { version = "0.7", optional = true }
 
@@ -61,6 +68,11 @@ junit-report = { version = "0.7", optional = true }
 humantime = "2.1"
 tempfile = "3.2"
 tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "time"] }
+
+[[test]]
+name = "json"
+required-features = ["output-json"]
+harness = false
 
 [[test]]
 name = "junit"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ For more examples check out the Book ([current][1] | [edge][2]).
 
 - `macros` (default): Enables step attributes and auto-wiring.
 - `timestamps`: Enables timestamps collecting for all [Cucumber] events.
+- `output-json` (implies `timestamps`): Enables support for outputting [JSON schema].
 - `output-junit` (implies `timestamps`): Enables support for outputting [JUnit XML report].
 
 
@@ -133,6 +134,7 @@ at your option.
 
 [Cucumber]: https://cucumber.io
 [Gherkin]: https://cucumber.io/docs/gherkin/reference
+[JSON schema]: https://github.com/cucumber/cucumber-json-schema
 [JUnit XML report]: https://llg.cubic.org/docs/junit
 
 [1]: https://cucumber-rs.github.io/cucumber/current

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For more examples check out the Book ([current][1] | [edge][2]).
 
 - `macros` (default): Enables step attributes and auto-wiring.
 - `timestamps`: Enables timestamps collecting for all [Cucumber] events.
-- `output-json` (implies `timestamps`): Enables support for outputting [JSON schema].
+- `output-json` (implies `timestamps`): Enables support for outputting in [Cucumber JSON format].
 - `output-junit` (implies `timestamps`): Enables support for outputting [JUnit XML report].
 
 
@@ -133,8 +133,8 @@ at your option.
 
 
 [Cucumber]: https://cucumber.io
+[Cucumber JSON format]: https://github.com/cucumber/cucumber-json-schema
 [Gherkin]: https://cucumber.io/docs/gherkin/reference
-[JSON schema]: https://github.com/cucumber/cucumber-json-schema
 [JUnit XML report]: https://llg.cubic.org/docs/junit
 
 [1]: https://cucumber-rs.github.io/cucumber/current

--- a/book/src/Features.md
+++ b/book/src/Features.md
@@ -474,9 +474,9 @@ World::cucumber()
 
 
 
-## JSON schema
+## Cucumber JSON format output
 
-Library provides an ability to output tests result in [JSON schema].
+Library provides an ability to output tests result in a [Cucumber JSON format].
 
 Just enable `output-json` library feature in your `Cargo.toml`:
 ```toml
@@ -518,6 +518,6 @@ World::cucumber()
 
 
 [Cucumber]: https://cucumber.io
+[Cucumber JSON format]: https://github.com/cucumber/cucumber-json-schema
 [Gherkin]: https://cucumber.io/docs/gherkin
-[JSON schema]: https://github.com/cucumber/cucumber-json-schema
 [JUnit XML report]: https://llg.cubic.org/docs/junit

--- a/book/src/Features.md
+++ b/book/src/Features.md
@@ -474,6 +474,50 @@ World::cucumber()
 
 
 
+## JSON schema
+
+Library provides an ability to output tests result in [JSON schema].
+
+Just enable `output-json` library feature in your `Cargo.toml`:
+```toml
+cucumber = { version = "0.11", features = ["output-json"] }
+```
+
+And configure [Cucumber]'s output to `writer::Json`:
+```rust
+# use std::{convert::Infallible, fs, io};
+# 
+# use async_trait::async_trait;
+# use cucumber::WorldInit;
+use cucumber::writer;
+
+# #[derive(Debug, WorldInit)]
+# struct World;
+# 
+# #[async_trait(?Send)]
+# impl cucumber::World for World {
+#     type Error = Infallible;
+# 
+#     async fn new() -> Result<Self, Self::Error> {
+#         Ok(World)
+#     }
+# }
+#
+# #[tokio::main]
+# async fn main() -> io::Result<()> {
+let file = fs::File::create(dbg!(format!("{}/target/schema.json", env!("CARGO_MANIFEST_DIR"))))?;
+World::cucumber()
+    .with_writer(writer::Json::new(file))
+    .run("tests/features/book")
+    .await;
+# Ok(())
+# }
+```
+
+
+
+
 [Cucumber]: https://cucumber.io
 [Gherkin]: https://cucumber.io/docs/gherkin
+[JSON schema]: https://github.com/cucumber/cucumber-json-schema
 [JUnit XML report]: https://llg.cubic.org/docs/junit

--- a/book/tests/Cargo.toml
+++ b/book/tests/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-cucumber = { version = "0.11.0-dev", path = "../..", features = ["output-junit"] }
+cucumber = { version = "0.11.0-dev", path = "../..", features = ["output-json", "output-junit"] }
 futures = "0.3"
 skeptic = "0.13"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/writer/json.rs
+++ b/src/writer/json.rs
@@ -1,0 +1,636 @@
+//! [JSON schema report][1] [`Writer`] implementation.
+//!
+//! [1]: https://github.com/cucumber/cucumber-json-schema
+
+// TODO: add failing after hook
+
+use std::{
+    fmt::Debug,
+    io,
+    time::{Duration, SystemTime},
+};
+
+use async_trait::async_trait;
+use inflector::Inflector as _;
+use serde::Serialize;
+
+use crate::{
+    cli, event,
+    feature::ExpandExamplesError,
+    parser,
+    writer::{self, basic::coerce_error},
+    Event, World, Writer, WriterExt as _,
+};
+
+/// [JSON schema report][1] [`Writer`] implementation outputting to an
+/// [`io::Write`] implementor.
+///
+/// Should be wrapped into [`writer::Normalized`] to work correctly, otherwise
+/// will panic in runtime as won't be able to form correct
+/// [JSON `testsuite`s][1].
+///
+/// [1]: https://github.com/cucumber/cucumber-json-schema
+#[derive(Clone, Debug)]
+pub struct Json<Out: io::Write> {
+    /// [`io::Write`] implementor to output XML report into.
+    output: Out,
+
+    /// Collection of [`Feature`]s to output [JSON report][1] into.
+    ///
+    /// [1]: https://github.com/cucumber/cucumber-json-schema
+    features: Vec<Feature>,
+
+    /// [`SystemTime`] when the current [`Step`] has started.
+    ///
+    /// [`Scenario`]: gherkin::Scenario
+    step_started: Option<SystemTime>,
+}
+
+#[async_trait(?Send)]
+impl<W: World + Debug, Out: io::Write> Writer<W> for Json<Out> {
+    type Cli = cli::Empty;
+
+    async fn handle_event(
+        &mut self,
+        event: parser::Result<Event<event::Cucumber<W>>>,
+        _: &Self::Cli,
+    ) {
+        self.handle_event(event);
+    }
+}
+
+impl<Out: io::Write> Json<Out> {
+    /// Creates a new normalized [`Json`] [`Writer`] outputting XML report into
+    /// the given `output`.
+    #[must_use]
+    pub fn new<W: Debug + World>(output: Out) -> writer::Normalized<W, Self> {
+        Self::raw(output).normalized()
+    }
+
+    /// Creates a new raw and unnormalized [`Json`] [`Writer`] outputting report
+    /// into the given `output`.
+    ///
+    /// # Warning
+    ///
+    /// It may panic in runtime as won't be able to form correct
+    /// [Json `testsuite`s][1] from unordered [`Cucumber` events][2].
+    ///
+    /// Use it only if you know what you're doing. Otherwise, consider using
+    /// [`Json::new()`] which creates an already [`Normalized`] version of
+    /// [`Json`] [`Writer`].
+    ///
+    /// [`Normalized`]: writer::Normalized
+    /// [1]: https://github.com/cucumber/cucumber-json-schema
+    /// [2]: crate::event::Cucumber
+    #[must_use]
+    pub fn raw(output: Out) -> Self {
+        Self {
+            output,
+            features: Vec::new(),
+            step_started: None,
+        }
+    }
+
+    fn handle_event<W>(
+        &mut self,
+        event: parser::Result<Event<event::Cucumber<W>>>,
+    ) {
+        use event::{Cucumber, Feature, Rule};
+
+        match event.map(event::Event::split) {
+            Ok((Cucumber::Feature(f, Feature::Scenario(sc, ev)), meta)) => {
+                self.handle_scenario_event(&f, None, &sc, ev, meta);
+            }
+            Ok((
+                Cucumber::Feature(f, Feature::Rule(r, Rule::Scenario(sc, ev))),
+                meta,
+            )) => {
+                self.handle_scenario_event(&f, Some(&r), &sc, ev, meta);
+            }
+            Err(_) => {
+                // add failure
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_scenario_event<W>(
+        &mut self,
+        feature: &gherkin::Feature,
+        rule: Option<&gherkin::Rule>,
+        scenario: &gherkin::Scenario,
+        ev: event::Scenario<W>,
+        meta: event::Metadata,
+    ) {
+        match ev {
+            event::Scenario::Started => {
+                self.get_or_insert_element(feature, rule, scenario, "scenario");
+            }
+            event::Scenario::Hook(_, event::Hook::Started) => {
+                self.step_started = Some(meta.at);
+            }
+            event::Scenario::Hook(ty, ev) => {
+                self.handle_hook_event(feature, scenario, ty, ev, meta);
+            }
+            event::Scenario::Background(_, event::Step::Started) => {
+                self.set_scenario_type(feature, rule, scenario, "background");
+            }
+            event::Scenario::Background(
+                st,
+                ev @ (event::Step::Passed(..)
+                | event::Step::Skipped
+                | event::Step::Failed(..)),
+            ) => {
+                let el = self.get_or_insert_element(
+                    feature,
+                    rule,
+                    scenario,
+                    "background",
+                );
+                let duration = meta
+                    .at
+                    .duration_since(self.step_started.take().unwrap())
+                    .unwrap();
+                // TODO: insert 'background', not 'scenario' type
+                el.steps.push(Step::new(&st, &ev, duration));
+            }
+            event::Scenario::Step(_, event::Step::Started) => {
+                self.step_started = Some(meta.at);
+                self.set_scenario_type(feature, rule, scenario, "scenario");
+            }
+            event::Scenario::Step(
+                st,
+                ev @ (event::Step::Passed(..)
+                | event::Step::Skipped
+                | event::Step::Failed(..)),
+            ) => {
+                let el = self
+                    .get_or_insert_element(feature, rule, scenario, "scenario");
+                let duration = meta
+                    .at
+                    .duration_since(self.step_started.take().unwrap())
+                    .unwrap();
+                el.steps.push(Step::new(&st, &ev, duration));
+            }
+        }
+    }
+
+    fn handle_hook_event<W>(
+        &mut self,
+        feature: &gherkin::Feature,
+        scenario: &gherkin::Scenario,
+        hook_ty: event::HookType,
+        event: event::Hook<W>,
+        meta: event::Metadata,
+    ) {
+        match event {
+            event::Hook::Started => {
+                self.step_started = Some(meta.at);
+            }
+            ev => {
+                let f =
+                    self.features.iter_mut().find(|&f| *f == *feature).unwrap();
+                let el = f
+                    .elements
+                    .iter_mut()
+                    .find(|el| el.name == scenario.name)
+                    .unwrap();
+                let duration = meta
+                    .at
+                    .duration_since(self.step_started.take().unwrap())
+                    .unwrap()
+                    .as_nanos();
+                let res = match ev {
+                    event::Hook::Started => unreachable!(),
+                    event::Hook::Passed => HookResult {
+                        result: StepResult {
+                            status: Status::Passed,
+                            duration,
+                            error_message: None,
+                        },
+                    },
+                    event::Hook::Failed(_, info) => HookResult {
+                        result: StepResult {
+                            status: Status::Failed,
+                            duration,
+                            error_message: Some(
+                                coerce_error(&info).into_owned(),
+                            ),
+                        },
+                    },
+                };
+                match hook_ty {
+                    event::HookType::Before => el.before.push(res),
+                    event::HookType::After => el.after.push(res),
+                }
+            }
+        }
+    }
+
+    fn get_or_insert_element(
+        &mut self,
+        feature: &gherkin::Feature,
+        rule: Option<&gherkin::Rule>,
+        scenario: &gherkin::Scenario,
+        ty: &'static str,
+    ) -> &mut Element {
+        let f = self
+            .features
+            .iter_mut()
+            .find(|&f| *f == *feature)
+            .unwrap_or_else(|| {
+                self.features.push(Feature::new(feature));
+                self.features.last_mut().unwrap()
+            });
+        f.elements
+            .iter_mut()
+            .find(|el| *el.name == scenario.name && el.r#type == ty)
+            .unwrap_or_else(|| {
+                f.elements.push(Element::new(feature, rule, scenario, ty));
+                f.elements.last_mut().unwrap()
+            })
+    }
+
+    fn set_scenario_type(
+        &mut self,
+        feature: &gherkin::Feature,
+        rule: Option<&gherkin::Rule>,
+        scenario: &gherkin::Scenario,
+        ty: &'static str,
+    ) {
+        let f = self
+            .features
+            .iter_mut()
+            .find(|&f| *f == *feature)
+            .unwrap_or_else(|| {
+                self.features.push(Feature::new(feature));
+                self.features.last_mut().unwrap()
+            });
+        let el = f
+            .elements
+            .iter_mut()
+            .find(|&el| *el.name == scenario.name && el.r#type == "scenario")
+            .unwrap_or_else(|| {
+                f.elements.push(Element::new(feature, rule, scenario, ty));
+                f.elements.last_mut().unwrap()
+            });
+        el.r#type = ty;
+    }
+}
+
+/// [`gherkin::Feature`] or [`gherkin::Scenario`] tag.
+#[derive(Clone, Debug, Serialize)]
+pub struct Tag {
+    /// [`Tag`] name.
+    name: String,
+
+    /// Line number.
+    ///
+    /// As [`gherkin`] parser omits this info, line number is taken from
+    /// [`gherkin::Feature`] or [`gherkin::Scenario`].
+    line: usize,
+}
+
+/// [`gherkin::Step`] run status.
+#[derive(Clone, Copy, Debug, Serialize)]
+pub enum Status {
+    /// [`event::Step::Passed`].
+    Passed,
+
+    /// [`event::Step::Failed`] with [`event::StepError::Panic`].
+    Failed,
+
+    /// [`event::Step::Skipped`].
+    Skipped,
+
+    /// [`event::Step::Failed`] with [`event::StepError::AmbiguousMatch`].
+    Ambiguous,
+
+    /// Never constructed and is here only to fully describe [JSON schema][1].
+    ///
+    /// [1]: https://github.com/cucumber/cucumber-json-schema
+    Undefined,
+
+    /// Never constructed and is here only to fully describe [JSON schema][1].
+    ///
+    /// [1]: https://github.com/cucumber/cucumber-json-schema
+    Pending,
+}
+
+/// [`gherkin::Step`] run result.
+#[derive(Clone, Debug, Serialize)]
+pub struct StepResult {
+    /// [`gherkin::Step`] [`Status`].
+    status: Status,
+
+    /// [`gherkin::Step`] execution time.
+    ///
+    /// While nowhere to be documented, `cucumber-jvm` uses nanoseconds.
+    /// Source: https://bit.ly/3onkLXJ
+    duration: u128,
+
+    /// Error message.
+    ///
+    /// Present only if [`Status::Failed`] or [`Status::Ambiguous`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_message: Option<String>,
+}
+
+/// [`gherkin::Step`].
+#[derive(Clone, Debug, Serialize)]
+pub struct Step {
+    /// [`gherkin::Step::keyword`] with trailing whitespace.
+    ///
+    /// Source: https://bit.ly/3c2q5tK
+    keyword: String,
+
+    /// [`gherkin::Step`] line number in `.feature` file.
+    line: usize,
+
+    /// [`gherkin::Step::name`].
+    name: String,
+
+    /// Never [`true`] and is here only to fully describe [JSON schema][1].
+    ///
+    /// [1]: https://github.com/cucumber/cucumber-json-schema
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    hidden: bool,
+
+    /// [`gherkin::Step`] run result.
+    result: StepResult,
+}
+
+impl Step {
+    /// Creates a new [`Step`].
+    fn new<W>(
+        step: &gherkin::Step,
+        event: &event::Step<W>,
+        duration: Duration,
+    ) -> Self {
+        Self {
+            keyword: format!("{} ", step.keyword),
+            line: step.position.line,
+            name: step.value.clone(),
+            hidden: false,
+            result: match event {
+                // TODO: maybe we should handle this differently
+                event::Step::Started => panic!(""),
+                event::Step::Passed(..) => StepResult {
+                    status: Status::Passed,
+                    duration: duration.as_nanos(),
+                    error_message: None,
+                },
+                event::Step::Failed(_, _, err) => match err {
+                    event::StepError::AmbiguousMatch(err) => StepResult {
+                        status: Status::Ambiguous,
+                        duration: duration.as_nanos(),
+                        error_message: Some(format!("{}", err)),
+                    },
+                    event::StepError::Panic(info) => StepResult {
+                        status: Status::Failed,
+                        duration: duration.as_micros(),
+                        error_message: Some(coerce_error(info).into_owned()),
+                    },
+                },
+                event::Step::Skipped => StepResult {
+                    status: Status::Skipped,
+                    duration: duration.as_nanos(),
+                    error_message: None,
+                },
+            },
+        }
+    }
+}
+
+/// TODO
+#[derive(Clone, Debug, Serialize)]
+pub struct HookResult {
+    /// TODO
+    result: StepResult,
+}
+
+/// [`gherkin::Background`] or [`gherkin::Scenario`] maybe prepended with
+/// [`gherkin::Rule::name`]. This is done because [JSON schema][1] doesn't have
+/// [`gherkin::Rule`].
+///
+/// [1]: https://github.com/cucumber/cucumber-json-schema
+#[derive(Clone, Debug, Serialize)]
+pub struct Element {
+    /// Doesn't appear in the [JSON schema][1], but present in
+    /// [generated test cases][2].
+    ///
+    /// [1]: https://github.com/cucumber/cucumber-json-schema
+    /// [2]: https://github.com/cucumber/cucumber-json-testdata-generator
+    after: Vec<HookResult>,
+
+    /// Doesn't appear in the [JSON schema][1], but present in
+    /// [generated test cases][2].
+    ///
+    /// [1]: https://github.com/cucumber/cucumber-json-schema
+    /// [2]: https://github.com/cucumber/cucumber-json-testdata-generator
+    before: Vec<HookResult>,
+
+    /// [`gherkin::Scenario::keyword`] with trailing whitespace.
+    ///
+    /// Source: https://bit.ly/3c2q5tK
+    keyword: String,
+
+    /// [`Element`] type.
+    ///
+    /// Only set to `background` or `scenario`, but [JSON schema][1] doesn't
+    /// constraint only to those values, so maybe a subject to change.
+    ///
+    /// [1]: https://github.com/cucumber/cucumber-json-schema
+    r#type: &'static str,
+
+    /// [`Element`] identifier. Doesn't have to be unique.
+    id: String,
+
+    /// [`gherkin::Scenario`] line number inside `.feature` file.
+    line: usize,
+
+    /// [`gherkin::Scenario::name`].
+    name: String,
+
+    /// [`gherkin::Scenario::tags`].
+    tags: Vec<Tag>,
+
+    /// [`gherkin::Scenario`] [`Step`]s.
+    steps: Vec<Step>,
+}
+
+impl Element {
+    fn new(
+        feature: &gherkin::Feature,
+        rule: Option<&gherkin::Rule>,
+        scenario: &gherkin::Scenario,
+        ty: &'static str,
+    ) -> Self {
+        Self {
+            after: Vec::new(),
+            before: Vec::new(),
+            keyword: format!("{} ", scenario.keyword),
+            r#type: ty,
+            id: format!(
+                "{}{}/{}",
+                feature.name,
+                rule.map(|r| format!("/{}", r.name)).unwrap_or_default(),
+                scenario.name,
+            ),
+            line: scenario.position.line,
+            name: scenario.name.clone(),
+            tags: scenario
+                .tags
+                .iter()
+                .map(|t| Tag {
+                    name: t.clone(),
+                    line: scenario.position.line,
+                })
+                .collect(),
+            steps: vec![],
+        }
+    }
+}
+
+/// [`gherkin::Feature`].
+#[derive(Clone, Debug, Serialize)]
+pub struct Feature {
+    /// [`gherkin::Feature::path`].
+    uri: Option<String>,
+
+    /// [`gherkin::Feature::keyword`] with trailing whitespace.
+    ///
+    /// Source: https://bit.ly/3c2q5tK
+    keyword: String,
+
+    /// [`gherkin::Feature::name`].
+    name: String,
+
+    /// [`gherkin::Feature::tags`]
+    tags: Vec<Tag>,
+
+    /// [`gherkin::Feature`] [`Element`]s.
+    elements: Vec<Element>,
+}
+
+impl Feature {
+    /// Creates a new [`Feature`].
+    fn new(feature: &gherkin::Feature) -> Self {
+        Self {
+            uri: feature
+                .path
+                .as_ref()
+                .and_then(|p| p.to_str())
+                .map(str::to_owned),
+            keyword: format!("{} ", feature.keyword),
+            name: feature.name.clone(),
+            tags: feature
+                .tags
+                .iter()
+                .map(|tag| Tag {
+                    name: tag.clone(),
+                    line: feature.position.line,
+                })
+                .collect(),
+            elements: Vec::new(),
+        }
+    }
+
+    /// Creates a new [`Feature`] from [`ExpandExamplesError`].
+    fn example_expansion_err(err: &ExpandExamplesError) -> Self {
+        Self {
+            uri: err
+                .path
+                .as_ref()
+                .and_then(|p| p.to_str())
+                .map(str::to_owned),
+            keyword: String::new(),
+            name: String::new(),
+            tags: vec![],
+            elements: vec![Element {
+                after: Vec::new(),
+                before: Vec::new(),
+                keyword: String::new(),
+                r#type: "scenario",
+                id: format!(
+                    "failed-to-expand-examples{}",
+                    err.path
+                        .as_ref()
+                        .and_then(|p| p.to_str())
+                        .unwrap_or_default(),
+                ),
+                line: 0,
+                name: String::new(),
+                tags: vec![],
+                steps: vec![Step {
+                    keyword: String::new(),
+                    line: err.pos.line,
+                    name: "scenario".to_owned(),
+                    hidden: false,
+                    result: StepResult {
+                        status: Status::Failed,
+                        duration: 0,
+                        error_message: Some(format!("{}", err)),
+                    },
+                }],
+            }],
+        }
+    }
+
+    /// Creates a new [`Feature`] from [`gherkin::ParseFileError`].
+    fn parsing_err(err: &gherkin::ParseFileError) -> Self {
+        let path = match err {
+            gherkin::ParseFileError::Reading { path, .. }
+            | gherkin::ParseFileError::Parsing { path, .. } => path,
+        }
+        .to_str()
+        .map(str::to_owned);
+
+        Self {
+            uri: path.clone(),
+            keyword: String::new(),
+            name: String::new(),
+            tags: vec![],
+            elements: vec![Element {
+                after: Vec::new(),
+                before: Vec::new(),
+                keyword: String::new(),
+                r#type: "scenario",
+                id: format!(
+                    "failed-to-parse{}",
+                    path.as_deref().unwrap_or_default(),
+                ),
+                line: 0,
+                name: String::new(),
+                tags: vec![],
+                steps: vec![Step {
+                    keyword: String::new(),
+                    line: 0,
+                    name: "scenario".to_owned(),
+                    hidden: false,
+                    result: StepResult {
+                        status: Status::Failed,
+                        duration: 0,
+                        error_message: Some(format!("{}", err)),
+                    },
+                }],
+            }],
+        }
+    }
+}
+
+impl PartialEq<gherkin::Feature> for Feature {
+    fn eq(&self, feature: &gherkin::Feature) -> bool {
+        self.uri
+            .as_ref()
+            .and_then(|uri| {
+                feature
+                    .path
+                    .as_ref()
+                    .and_then(|p| p.to_str())
+                    .map(|path| uri == path)
+            })
+            .unwrap_or_default()
+            && self.name == feature.name
+    }
+}

--- a/src/writer/json.rs
+++ b/src/writer/json.rs
@@ -16,25 +16,26 @@ use crate::{
     Event, World, Writer, WriterExt as _,
 };
 
-/// [JSON schema report][1] [`Writer`] implementation outputting to an
-/// [`io::Write`] implementor.
+/// [JSON schema][1] [`Writer`] implementation outputting to an [`io::Write`]
+/// implementor.
 ///
 /// Should be wrapped into [`writer::Normalized`] to work correctly, otherwise
-/// will panic in runtime as won't be able to form correct
-/// [JSON `testsuite`s][1].
+/// will panic in runtime as won't be able to form correct [JSON schema][1].
 ///
 /// [1]: https://github.com/cucumber/cucumber-json-schema
 #[derive(Clone, Debug)]
 pub struct Json<Out: io::Write> {
-    /// [`io::Write`] implementor to output XML report into.
+    /// [`io::Write`] implementor to output [JSON schema][1] into.
+    ///
+    /// [1]: https://github.com/cucumber/cucumber-json-schema
     output: Out,
 
-    /// Collection of [`Feature`]s to output [JSON report][1] into.
+    /// Collection of [`Feature`]s to output [JSON schema][1] into.
     ///
     /// [1]: https://github.com/cucumber/cucumber-json-schema
     features: Vec<Feature>,
 
-    /// [`SystemTime`] when the current [`Step`]/[`Hook`] has started.
+    /// [`SystemTime`] when the current [`Hook`]/[`Step`] has started.
     ///
     /// [`Scenario`]: gherkin::Scenario
     /// [`Hook`]: event::Hook
@@ -55,8 +56,10 @@ impl<W: World + Debug, Out: io::Write> Writer<W> for Json<Out> {
 }
 
 impl<Out: io::Write> Json<Out> {
-    /// Creates a new normalized [`Json`] [`Writer`] outputting JSON report into
-    /// the given `output`.
+    /// Creates a new normalized [`Json`] [`Writer`] outputting [JSON schema][1]
+    /// into the given `output`.
+    ///
+    /// [1]: https://github.com/cucumber/cucumber-json-schema
     #[must_use]
     pub fn new<W: Debug + World>(output: Out) -> writer::Normalized<W, Self> {
         Self::raw(output).normalized()
@@ -68,7 +71,7 @@ impl<Out: io::Write> Json<Out> {
     /// # Warning
     ///
     /// It may panic in runtime as won't be able to form correct
-    /// [Json `testsuite`s][1] from unordered [`Cucumber` events][2].
+    /// [JSON schema][1] from unordered [`Cucumber` events][2].
     ///
     /// Use it only if you know what you're doing. Otherwise, consider using
     /// [`Json::new()`] which creates an already [`Normalized`] version of
@@ -299,7 +302,7 @@ impl<Out: io::Write> Json<Out> {
         scenario: &gherkin::Scenario,
         ty: &'static str,
     ) -> &mut Element {
-        let pos = self
+        let f_pos = self
             .features
             .iter()
             .position(|f| f == feature)
@@ -307,8 +310,11 @@ impl<Out: io::Write> Json<Out> {
                 self.features.push(Feature::new(feature));
                 self.features.len() - 1
             });
-        let f = self.features.get_mut(pos).unwrap_or_else(|| unreachable!());
-        let pos = f
+        let f = self
+            .features
+            .get_mut(f_pos)
+            .unwrap_or_else(|| unreachable!());
+        let el_pos = f
             .elements
             .iter()
             .position(|el| {
@@ -326,7 +332,7 @@ impl<Out: io::Write> Json<Out> {
                 f.elements.push(Element::new(feature, rule, scenario, ty));
                 f.elements.len() - 1
             });
-        f.elements.get_mut(pos).unwrap_or_else(|| unreachable!())
+        f.elements.get_mut(el_pos).unwrap_or_else(|| unreachable!())
     }
 }
 
@@ -410,13 +416,13 @@ pub struct Step {
     pub result: RunResult,
 }
 
-/// [`Before`] or [`After`] run result.
+/// [`Before`] or [`After`] hook run result.
 ///
 /// [`Before`]: event::HookType::Before
 /// [`After`]: event::HookType::After
 #[derive(Clone, Debug, Serialize)]
 pub struct HookResult {
-    /// [`Before`] or [`After`] run result.
+    /// [`Before`] or [`After`] hook run result.
     ///
     /// [`Before`]: event::HookType::Before
     /// [`After`]: event::HookType::After

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -14,6 +14,8 @@
 
 pub mod basic;
 pub mod fail_on_skipped;
+#[cfg(feature = "output-json")]
+pub mod json;
 #[cfg(feature = "output-junit")]
 pub mod junit;
 pub mod normalized;
@@ -27,6 +29,9 @@ use structopt::StructOptInternal;
 
 use crate::{event, parser, Event, World};
 
+#[cfg(feature = "output-json")]
+#[doc(inline)]
+pub use self::json::Json;
 #[cfg(feature = "output-junit")]
 #[doc(inline)]
 pub use self::junit::JUnit;

--- a/tests/features/wait/nested/rule.feature
+++ b/tests/features/wait/nested/rule.feature
@@ -10,6 +10,7 @@ Feature: Basic
     Then 1 sec
 
   Rule: rule
+    @fail_before
     Scenario: 2 secs
       Given 2 secs
       When 2 secs

--- a/tests/features/wait/outline.feature
+++ b/tests/features/wait/outline.feature
@@ -1,6 +1,6 @@
 Feature: Outline
 
-  @tag
+  @tag @fail_after
   Scenario Outline: wait
     Given <wait> secs
     When <wait> secs

--- a/tests/features/wait/rule.feature
+++ b/tests/features/wait/rule.feature
@@ -10,7 +10,7 @@ Feature: Basic
     Then 1 sec
 
   Rule: rule
-    @fail_after
+    @fail_before
     Scenario: 2 secs
       Given 2 secs
       When 2 secs

--- a/tests/features/wait/rule.feature
+++ b/tests/features/wait/rule.feature
@@ -10,6 +10,7 @@ Feature: Basic
     Then 1 sec
 
   Rule: rule
+    @fail_after
     Scenario: 2 secs
       Given 2 secs
       When 2 secs

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,0 +1,62 @@
+use std::{convert::Infallible, fs, io::Read as _};
+
+use async_trait::async_trait;
+use cucumber::{given, then, when, writer, WorldInit, WriterExt as _};
+use regex::Regex;
+use tempfile::NamedTempFile;
+
+#[given(regex = r"(\d+) secs?")]
+#[when(regex = r"(\d+) secs?")]
+#[then(regex = r"(\d+) secs?")]
+fn step(world: &mut World) {
+    world.0 += 1;
+    if world.0 > 3 {
+        panic!("Too much!");
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let mut file = NamedTempFile::new().unwrap();
+    drop(
+        World::cucumber()
+            .with_writer(writer::Json::new(file.reopen().unwrap()))
+            .run("tests/features/wait")
+            .await,
+    );
+
+    let mut buffer = String::new();
+    file.read_to_string(&mut buffer).unwrap();
+
+    // Required to strip out non-deterministic parts of output, so we could
+    // compare them well.
+    let non_deterministic = Regex::new(
+        "\"uri\":\\s?\"[^\"]*\"\
+             |\"duration\":\\s?\\d+\
+             |\"id\":\\s?\"failed[^\"]*\"\
+             |\"error_message\":\\s?\"Could[^\"]*\"\
+             |\n\
+             |\\s",
+    )
+    .unwrap();
+
+    assert_eq!(
+        non_deterministic.replace_all(&buffer, ""),
+        non_deterministic.replace_all(
+            &fs::read_to_string("tests/json/correct.json").unwrap(),
+            "",
+        ),
+    );
+}
+
+#[derive(Clone, Copy, Debug, WorldInit)]
+struct World(usize);
+
+#[async_trait(?Send)]
+impl cucumber::World for World {
+    type Error = Infallible;
+
+    async fn new() -> Result<Self, Self::Error> {
+        Ok(World(0))
+    }
+}

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -49,11 +49,11 @@ async fn main() {
     // compare them well.
     let non_deterministic = RegexBuilder::new(
         "\"uri\":\\s?\"[^\"]*\"\
-             |\"duration\":\\s?\\d+\
-             |\"id\":\\s?\"failed[^\"]*\"\
-             |\"error_message\":\\s?\"Could[^\"]*\"\
-             |\n\
-             |\\s",
+         |\"duration\":\\s?\\d+\
+         |\"id\":\\s?\"failed[^\"]*\"\
+         |\"error_message\":\\s?\"Could[^\"]*\"\
+         |\n\
+         |\\s",
     )
     .multi_line(true)
     .build()

--- a/tests/json/correct.json
+++ b/tests/json/correct.json
@@ -1,0 +1,774 @@
+[
+  {
+    "uri": "/cucumber/tests/features/wait/invalid.feature",
+    "keyword": "",
+    "name": "",
+    "tags": [],
+    "elements": [
+      {
+        "keyword": "",
+        "type": "scenario",
+        "id": "failed-to-parse/cucumber/tests/features/wait/invalid.feature",
+        "line": 0,
+        "name": "",
+        "tags": [],
+        "steps": [
+          {
+            "keyword": "",
+            "line": 0,
+            "name": "scenario",
+            "result": {
+              "status": "Failed",
+              "duration": 0,
+              "error_message": "Could not parse feature file: /cucumber/tests/features/wait/invalid.feature"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "uri": "/cucumber/tests/features/wait/rule.feature",
+    "keyword": "Feature ",
+    "name": "Basic",
+    "tags": [],
+    "elements": [
+      {
+        "keyword": "Scenario ",
+        "type": "background",
+        "id": "basic/1-sec",
+        "line": 6,
+        "name": " 1 sec",
+        "tags": [
+          {
+            "name": "serial",
+            "line": 6
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 3,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 584000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario ",
+        "type": "scenario",
+        "id": "basic/1-sec",
+        "line": 6,
+        "name": " 1 sec",
+        "tags": [
+          {
+            "name": "serial",
+            "line": 6
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 7,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 620000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario ",
+        "type": "scenario",
+        "id": "basic/1-sec",
+        "line": 6,
+        "name": " 1 sec",
+        "tags": [
+          {
+            "name": "serial",
+            "line": 6
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "When ",
+            "line": 8,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 1178000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario ",
+        "type": "scenario",
+        "id": "basic/1-sec",
+        "line": 6,
+        "name": " 1 sec",
+        "tags": [
+          {
+            "name": "serial",
+            "line": 6
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Then ",
+            "line": 9,
+            "name": "unknown",
+            "result": {
+              "status": "Skipped",
+              "duration": 1440000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario ",
+        "type": "background",
+        "id": "basic/rule/2-secs",
+        "line": 13,
+        "name": "rule 2 secs",
+        "tags": [],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 3,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 42000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario ",
+        "type": "scenario",
+        "id": "basic/rule/2-secs",
+        "line": 13,
+        "name": "rule 2 secs",
+        "tags": [],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 14,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 130000
+            }
+          },
+          {
+            "keyword": "When ",
+            "line": 15,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 213000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "line": 16,
+            "name": "2 secs",
+            "result": {
+              "status": "Failed",
+              "duration": 871,
+              "error_message": "Too much!"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "uri": "/cucumber/tests/features/wait/nested/rule.feature",
+    "keyword": "Feature ",
+    "name": "Basic",
+    "tags": [],
+    "elements": [
+      {
+        "keyword": "Scenario ",
+        "type": "background",
+        "id": "basic/1-sec",
+        "line": 6,
+        "name": " 1 sec",
+        "tags": [
+          {
+            "name": "serial",
+            "line": 6
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 3,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 39000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario ",
+        "type": "scenario",
+        "id": "basic/1-sec",
+        "line": 6,
+        "name": " 1 sec",
+        "tags": [
+          {
+            "name": "serial",
+            "line": 6
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 7,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 71000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario ",
+        "type": "scenario",
+        "id": "basic/1-sec",
+        "line": 6,
+        "name": " 1 sec",
+        "tags": [
+          {
+            "name": "serial",
+            "line": 6
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "When ",
+            "line": 8,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 96000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario ",
+        "type": "scenario",
+        "id": "basic/1-sec",
+        "line": 6,
+        "name": " 1 sec",
+        "tags": [
+          {
+            "name": "serial",
+            "line": 6
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Then ",
+            "line": 9,
+            "name": "unknown",
+            "result": {
+              "status": "Skipped",
+              "duration": 112000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario ",
+        "type": "background",
+        "id": "basic/rule/2-secs",
+        "line": 13,
+        "name": "rule 2 secs",
+        "tags": [],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 3,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 42000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario ",
+        "type": "scenario",
+        "id": "basic/rule/2-secs",
+        "line": 13,
+        "name": "rule 2 secs",
+        "tags": [],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 14,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 76000
+            }
+          },
+          {
+            "keyword": "When ",
+            "line": 15,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 102000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "line": 16,
+            "name": "2 secs",
+            "result": {
+              "status": "Failed",
+              "duration": 138,
+              "error_message": "Too much!"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "uri": "/cucumber/tests/features/wait/outline.feature",
+    "keyword": "Feature ",
+    "name": "Outline",
+    "tags": [],
+    "elements": [
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 12,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 12
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 6,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 38000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 12,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 12
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "When ",
+            "line": 7,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 64000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 12,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 12
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Then ",
+            "line": 8,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 95000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 13,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 13
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 6,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 35000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 13,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 13
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "When ",
+            "line": 7,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 61000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 13,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 13
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Then ",
+            "line": 8,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 86000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 14,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 14
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 6,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 37000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 14,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 14
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "When ",
+            "line": 7,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 68000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 14,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 14
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Then ",
+            "line": 8,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 93000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 15,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 15
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 6,
+            "name": "5 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 36000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 15,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 15
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "When ",
+            "line": 7,
+            "name": "5 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 62000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 15,
+        "name": " wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 15
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Then ",
+            "line": 8,
+            "name": "5 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 87000
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "uri": "/cucumber/tests/features/wait/rule_outline.feature",
+    "keyword": "Feature ",
+    "name": "Rule Outline",
+    "tags": [],
+    "elements": [
+      {
+        "keyword": "Scenario Outline ",
+        "type": "scenario",
+        "id": "rule-outline/to-them-all/wait",
+        "line": 10,
+        "name": "To them all wait",
+        "tags": [],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 5,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 52000
+            }
+          },
+          {
+            "keyword": "When ",
+            "line": 6,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 82000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "line": 7,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 107000
+            }
+          },
+          {
+            "keyword": "Given ",
+            "line": 5,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 37000
+            }
+          },
+          {
+            "keyword": "When ",
+            "line": 6,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 62000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "line": 7,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 86000
+            }
+          },
+          {
+            "keyword": "Given ",
+            "line": 5,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 42000
+            }
+          },
+          {
+            "keyword": "When ",
+            "line": 6,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 68000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "line": 7,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 92000
+            }
+          },
+          {
+            "keyword": "Given ",
+            "line": 5,
+            "name": "5 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 37000
+            }
+          },
+          {
+            "keyword": "When ",
+            "line": 6,
+            "name": "5 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 63000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "line": 7,
+            "name": "5 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 86000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/json/correct.json
+++ b/tests/json/correct.json
@@ -1,6 +1,6 @@
 [
   {
-    "uri": "/cucumber/tests/features/wait/invalid.feature",
+    "uri": "/Users/work/Work/cucumber/tests/features/wait/invalid.feature",
     "keyword": "",
     "name": "",
     "tags": [],
@@ -8,7 +8,7 @@
       {
         "keyword": "",
         "type": "scenario",
-        "id": "failed-to-parse/cucumber/tests/features/wait/invalid.feature",
+        "id": "failed-to-parse/Users/work/Work/cucumber/tests/features/wait/invalid.feature",
         "line": 0,
         "name": "",
         "tags": [],
@@ -20,7 +20,7 @@
             "result": {
               "status": "Failed",
               "duration": 0,
-              "error_message": "Could not parse feature file: /cucumber/tests/features/wait/invalid.feature"
+              "error_message": "Could not parse feature file: /Users/work/Work/cucumber/tests/features/wait/invalid.feature"
             }
           }
         ]
@@ -28,41 +28,33 @@
     ]
   },
   {
-    "uri": "/cucumber/tests/features/wait/rule.feature",
-    "keyword": "Feature ",
+    "uri": "/Users/work/Work/cucumber/tests/features/wait/rule.feature",
+    "keyword": "Feature",
     "name": "Basic",
     "tags": [],
     "elements": [
       {
-        "keyword": "Scenario ",
-        "type": "background",
-        "id": "basic/1-sec",
-        "line": 6,
-        "name": " 1 sec",
-        "tags": [
+        "after": [
           {
-            "name": "serial",
-            "line": 6
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "Given ",
-            "line": 3,
-            "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 584000
+              "duration": 4000
             }
           }
-        ]
-      },
-      {
-        "keyword": "Scenario ",
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 9000
+            }
+          }
+        ],
+        "keyword": "Scenario",
         "type": "scenario",
         "id": "basic/1-sec",
         "line": 6,
-        "name": " 1 sec",
+        "name": "1 sec",
         "tags": [
           {
             "name": "serial",
@@ -71,488 +63,409 @@
         ],
         "steps": [
           {
-            "keyword": "Given ",
+            "keyword": "Given",
             "line": 7,
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 620000
+              "duration": 25000
             }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario ",
-        "type": "scenario",
-        "id": "basic/1-sec",
-        "line": 6,
-        "name": " 1 sec",
-        "tags": [
+          },
           {
-            "name": "serial",
-            "line": 6
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "When ",
+            "keyword": "When",
             "line": 8,
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 1178000
+              "duration": 539000
             }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario ",
-        "type": "scenario",
-        "id": "basic/1-sec",
-        "line": 6,
-        "name": " 1 sec",
-        "tags": [
+          },
           {
-            "name": "serial",
-            "line": 6
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "Then ",
+            "keyword": "Then",
             "line": 9,
             "name": "unknown",
             "result": {
               "status": "Skipped",
-              "duration": 1440000
+              "duration": 245000
             }
           }
         ]
       },
       {
-        "keyword": "Scenario ",
+        "keyword": "Background",
         "type": "background",
-        "id": "basic/rule/2-secs",
-        "line": 13,
-        "name": "rule 2 secs",
-        "tags": [],
+        "id": "basic/1-sec",
+        "line": 6,
+        "name": "1 sec",
+        "tags": [
+          {
+            "name": "serial",
+            "line": 6
+          }
+        ],
         "steps": [
           {
-            "keyword": "Given ",
+            "keyword": "Given",
             "line": 3,
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 42000
+              "duration": 544000
             }
           }
         ]
       },
       {
-        "keyword": "Scenario ",
-        "type": "scenario",
-        "id": "basic/rule/2-secs",
-        "line": 13,
-        "name": "rule 2 secs",
-        "tags": [],
-        "steps": [
+        "after": [
           {
-            "keyword": "Given ",
-            "line": 14,
-            "name": "2 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 130000
-            }
-          },
-          {
-            "keyword": "When ",
-            "line": 15,
-            "name": "2 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 213000
-            }
-          },
-          {
-            "keyword": "Then ",
-            "line": 16,
-            "name": "2 secs",
             "result": {
               "status": "Failed",
-              "duration": 871,
-              "error_message": "Too much!"
+              "duration": 12000,
+              "error_message": "Tag!"
             }
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "uri": "/cucumber/tests/features/wait/nested/rule.feature",
-    "keyword": "Feature ",
-    "name": "Basic",
-    "tags": [],
-    "elements": [
-      {
-        "keyword": "Scenario ",
-        "type": "background",
-        "id": "basic/1-sec",
-        "line": 6,
-        "name": " 1 sec",
-        "tags": [
-          {
-            "name": "serial",
-            "line": 6
           }
         ],
-        "steps": [
+        "before": [
           {
-            "keyword": "Given ",
-            "line": 3,
-            "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 39000
+              "duration": 7000
             }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario ",
-        "type": "scenario",
-        "id": "basic/1-sec",
-        "line": 6,
-        "name": " 1 sec",
-        "tags": [
-          {
-            "name": "serial",
-            "line": 6
           }
         ],
-        "steps": [
-          {
-            "keyword": "Given ",
-            "line": 7,
-            "name": "1 sec",
-            "result": {
-              "status": "Passed",
-              "duration": 71000
-            }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario ",
-        "type": "scenario",
-        "id": "basic/1-sec",
-        "line": 6,
-        "name": " 1 sec",
-        "tags": [
-          {
-            "name": "serial",
-            "line": 6
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "When ",
-            "line": 8,
-            "name": "1 sec",
-            "result": {
-              "status": "Passed",
-              "duration": 96000
-            }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario ",
-        "type": "scenario",
-        "id": "basic/1-sec",
-        "line": 6,
-        "name": " 1 sec",
-        "tags": [
-          {
-            "name": "serial",
-            "line": 6
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "Then ",
-            "line": 9,
-            "name": "unknown",
-            "result": {
-              "status": "Skipped",
-              "duration": 112000
-            }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario ",
-        "type": "background",
-        "id": "basic/rule/2-secs",
-        "line": 13,
-        "name": "rule 2 secs",
-        "tags": [],
-        "steps": [
-          {
-            "keyword": "Given ",
-            "line": 3,
-            "name": "1 sec",
-            "result": {
-              "status": "Passed",
-              "duration": 42000
-            }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario ",
+        "keyword": "Scenario",
         "type": "scenario",
         "id": "basic/rule/2-secs",
-        "line": 13,
-        "name": "rule 2 secs",
-        "tags": [],
-        "steps": [
-          {
-            "keyword": "Given ",
-            "line": 14,
-            "name": "2 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 76000
-            }
-          },
-          {
-            "keyword": "When ",
-            "line": 15,
-            "name": "2 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 102000
-            }
-          },
-          {
-            "keyword": "Then ",
-            "line": 16,
-            "name": "2 secs",
-            "result": {
-              "status": "Failed",
-              "duration": 138,
-              "error_message": "Too much!"
-            }
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "uri": "/cucumber/tests/features/wait/outline.feature",
-    "keyword": "Feature ",
-    "name": "Outline",
-    "tags": [],
-    "elements": [
-      {
-        "keyword": "Scenario Outline ",
-        "type": "scenario",
-        "id": "outline/wait",
-        "line": 12,
-        "name": " wait",
-        "tags": [
-          {
-            "name": "tag",
-            "line": 12
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "Given ",
-            "line": 6,
-            "name": "2 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 38000
-            }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario Outline ",
-        "type": "scenario",
-        "id": "outline/wait",
-        "line": 12,
-        "name": " wait",
-        "tags": [
-          {
-            "name": "tag",
-            "line": 12
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "When ",
-            "line": 7,
-            "name": "2 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 64000
-            }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario Outline ",
-        "type": "scenario",
-        "id": "outline/wait",
-        "line": 12,
-        "name": " wait",
-        "tags": [
-          {
-            "name": "tag",
-            "line": 12
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "Then ",
-            "line": 8,
-            "name": "2 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 95000
-            }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario Outline ",
-        "type": "scenario",
-        "id": "outline/wait",
-        "line": 13,
-        "name": " wait",
-        "tags": [
-          {
-            "name": "tag",
-            "line": 13
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "Given ",
-            "line": 6,
-            "name": "1 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 35000
-            }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario Outline ",
-        "type": "scenario",
-        "id": "outline/wait",
-        "line": 13,
-        "name": " wait",
-        "tags": [
-          {
-            "name": "tag",
-            "line": 13
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "When ",
-            "line": 7,
-            "name": "1 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 61000
-            }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario Outline ",
-        "type": "scenario",
-        "id": "outline/wait",
-        "line": 13,
-        "name": " wait",
-        "tags": [
-          {
-            "name": "tag",
-            "line": 13
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "Then ",
-            "line": 8,
-            "name": "1 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 86000
-            }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario Outline ",
-        "type": "scenario",
-        "id": "outline/wait",
         "line": 14,
-        "name": " wait",
+        "name": "rule 2 secs",
         "tags": [
           {
-            "name": "tag",
+            "name": "fail_after",
             "line": 14
           }
         ],
         "steps": [
           {
-            "keyword": "Given ",
-            "line": 6,
-            "name": "1 secs",
+            "keyword": "Given",
+            "line": 15,
+            "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 37000
+              "duration": 73000
             }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario Outline ",
-        "type": "scenario",
-        "id": "outline/wait",
-        "line": 14,
-        "name": " wait",
-        "tags": [
+          },
           {
-            "name": "tag",
-            "line": 14
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "When ",
-            "line": 7,
-            "name": "1 secs",
+            "keyword": "When",
+            "line": 16,
+            "name": "2 secs",
             "result": {
               "status": "Passed",
               "duration": 68000
             }
+          },
+          {
+            "keyword": "Then",
+            "line": 17,
+            "name": "2 secs",
+            "result": {
+              "status": "Failed",
+              "duration": 616000,
+              "error_message": "Too much!"
+            }
           }
         ]
       },
       {
-        "keyword": "Scenario Outline ",
+        "keyword": "Background",
+        "type": "background",
+        "id": "basic/rule/2-secs",
+        "line": 14,
+        "name": "rule 2 secs",
+        "tags": [
+          {
+            "name": "fail_after",
+            "line": 14
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given",
+            "line": 3,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 32000
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "uri": "/Users/work/Work/cucumber/tests/features/wait/nested/rule.feature",
+    "keyword": "Feature",
+    "name": "Basic",
+    "tags": [],
+    "elements": [
+      {
+        "after": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 5000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 9000
+            }
+          }
+        ],
+        "keyword": "Scenario",
+        "type": "scenario",
+        "id": "basic/1-sec",
+        "line": 6,
+        "name": "1 sec",
+        "tags": [
+          {
+            "name": "serial",
+            "line": 6
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given",
+            "line": 7,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 38000
+            }
+          },
+          {
+            "keyword": "When",
+            "line": 8,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 34000
+            }
+          },
+          {
+            "keyword": "Then",
+            "line": 9,
+            "name": "unknown",
+            "result": {
+              "status": "Skipped",
+              "duration": 12000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Background",
+        "type": "background",
+        "id": "basic/1-sec",
+        "line": 6,
+        "name": "1 sec",
+        "tags": [
+          {
+            "name": "serial",
+            "line": 6
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given",
+            "line": 3,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 42000
+            }
+          }
+        ]
+      },
+      {
+        "after": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 2000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Failed",
+              "duration": 16000,
+              "error_message": "Tag!"
+            }
+          }
+        ],
+        "keyword": "Scenario",
+        "type": "scenario",
+        "id": "basic/rule/2-secs",
+        "line": 14,
+        "name": "rule 2 secs",
+        "tags": [
+          {
+            "name": "fail_before",
+            "line": 14
+          }
+        ],
+        "steps": []
+      }
+    ]
+  },
+  {
+    "uri": "/Users/work/Work/cucumber/tests/features/wait/outline.feature",
+    "keyword": "Feature",
+    "name": "Outline",
+    "tags": [],
+    "elements": [
+      {
+        "after": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 3000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 5000
+            }
+          }
+        ],
+        "keyword": "Scenario Outline",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 12,
+        "name": "wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 12
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given",
+            "line": 6,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 34000
+            }
+          },
+          {
+            "keyword": "When",
+            "line": 7,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 22000
+            }
+          },
+          {
+            "keyword": "Then",
+            "line": 8,
+            "name": "2 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 21000
+            }
+          }
+        ]
+      },
+      {
+        "after": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 2000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 5000
+            }
+          }
+        ],
+        "keyword": "Scenario Outline",
+        "type": "scenario",
+        "id": "outline/wait",
+        "line": 13,
+        "name": "wait",
+        "tags": [
+          {
+            "name": "tag",
+            "line": 13
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given",
+            "line": 6,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 27000
+            }
+          },
+          {
+            "keyword": "When",
+            "line": 7,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 22000
+            }
+          },
+          {
+            "keyword": "Then",
+            "line": 8,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 25000
+            }
+          }
+        ]
+      },
+      {
+        "after": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 3000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 5000
+            }
+          }
+        ],
+        "keyword": "Scenario Outline",
         "type": "scenario",
         "id": "outline/wait",
         "line": 14,
-        "name": " wait",
+        "name": "wait",
         "tags": [
           {
             "name": "tag",
@@ -561,22 +474,56 @@
         ],
         "steps": [
           {
-            "keyword": "Then ",
+            "keyword": "Given",
+            "line": 6,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 28000
+            }
+          },
+          {
+            "keyword": "When",
+            "line": 7,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 21000
+            }
+          },
+          {
+            "keyword": "Then",
             "line": 8,
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 93000
+              "duration": 21000
             }
           }
         ]
       },
       {
-        "keyword": "Scenario Outline ",
+        "after": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 2000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 5000
+            }
+          }
+        ],
+        "keyword": "Scenario Outline",
         "type": "scenario",
         "id": "outline/wait",
         "line": 15,
-        "name": " wait",
+        "name": "wait",
         "tags": [
           {
             "name": "tag",
@@ -585,60 +532,30 @@
         ],
         "steps": [
           {
-            "keyword": "Given ",
+            "keyword": "Given",
             "line": 6,
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 36000
+              "duration": 29000
             }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario Outline ",
-        "type": "scenario",
-        "id": "outline/wait",
-        "line": 15,
-        "name": " wait",
-        "tags": [
+          },
           {
-            "name": "tag",
-            "line": 15
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "When ",
+            "keyword": "When",
             "line": 7,
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 62000
+              "duration": 21000
             }
-          }
-        ]
-      },
-      {
-        "keyword": "Scenario Outline ",
-        "type": "scenario",
-        "id": "outline/wait",
-        "line": 15,
-        "name": " wait",
-        "tags": [
+          },
           {
-            "name": "tag",
-            "line": 15
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "Then ",
+            "keyword": "Then",
             "line": 8,
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 87000
+              "duration": 21000
             }
           }
         ]
@@ -646,13 +563,29 @@
     ]
   },
   {
-    "uri": "/cucumber/tests/features/wait/rule_outline.feature",
-    "keyword": "Feature ",
+    "uri": "/Users/work/Work/cucumber/tests/features/wait/rule_outline.feature",
+    "keyword": "Feature",
     "name": "Rule Outline",
     "tags": [],
     "elements": [
       {
-        "keyword": "Scenario Outline ",
+        "after": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 3000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 5000
+            }
+          }
+        ],
+        "keyword": "Scenario Outline",
         "type": "scenario",
         "id": "rule-outline/to-them-all/wait",
         "line": 10,
@@ -660,111 +593,189 @@
         "tags": [],
         "steps": [
           {
-            "keyword": "Given ",
+            "keyword": "Given",
             "line": 5,
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 52000
+              "duration": 28000
             }
           },
           {
-            "keyword": "When ",
+            "keyword": "When",
             "line": 6,
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 82000
+              "duration": 21000
             }
           },
           {
-            "keyword": "Then ",
+            "keyword": "Then",
             "line": 7,
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 107000
+              "duration": 22000
             }
-          },
+          }
+        ]
+      },
+      {
+        "after": [
           {
-            "keyword": "Given ",
+            "result": {
+              "status": "Passed",
+              "duration": 2000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 5000
+            }
+          }
+        ],
+        "keyword": "Scenario Outline",
+        "type": "scenario",
+        "id": "rule-outline/to-them-all/wait",
+        "line": 11,
+        "name": "To them all wait",
+        "tags": [],
+        "steps": [
+          {
+            "keyword": "Given",
             "line": 5,
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 37000
+              "duration": 27000
             }
           },
           {
-            "keyword": "When ",
+            "keyword": "When",
             "line": 6,
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 62000
+              "duration": 21000
             }
           },
           {
-            "keyword": "Then ",
+            "keyword": "Then",
             "line": 7,
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 86000
+              "duration": 20000
             }
-          },
+          }
+        ]
+      },
+      {
+        "after": [
           {
-            "keyword": "Given ",
+            "result": {
+              "status": "Passed",
+              "duration": 2000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 9000
+            }
+          }
+        ],
+        "keyword": "Scenario Outline",
+        "type": "scenario",
+        "id": "rule-outline/to-them-all/wait",
+        "line": 12,
+        "name": "To them all wait",
+        "tags": [],
+        "steps": [
+          {
+            "keyword": "Given",
             "line": 5,
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 42000
+              "duration": 27000
             }
           },
           {
-            "keyword": "When ",
+            "keyword": "When",
             "line": 6,
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 68000
+              "duration": 21000
             }
           },
           {
-            "keyword": "Then ",
+            "keyword": "Then",
             "line": 7,
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 92000
+              "duration": 20000
             }
-          },
+          }
+        ]
+      },
+      {
+        "after": [
           {
-            "keyword": "Given ",
+            "result": {
+              "status": "Passed",
+              "duration": 2000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 5000
+            }
+          }
+        ],
+        "keyword": "Scenario Outline",
+        "type": "scenario",
+        "id": "rule-outline/to-them-all/wait",
+        "line": 13,
+        "name": "To them all wait",
+        "tags": [],
+        "steps": [
+          {
+            "keyword": "Given",
             "line": 5,
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 37000
+              "duration": 27000
             }
           },
           {
-            "keyword": "When ",
+            "keyword": "When",
             "line": 6,
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 63000
+              "duration": 20000
             }
           },
           {
-            "keyword": "Then ",
+            "keyword": "Then",
             "line": 7,
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 86000
+              "duration": 21000
             }
           }
         ]

--- a/tests/json/correct.json
+++ b/tests/json/correct.json
@@ -46,7 +46,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 9000
+              "duration": 15000
             }
           }
         ],
@@ -68,7 +68,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 25000
+              "duration": 27000
             }
           },
           {
@@ -77,7 +77,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 539000
+              "duration": 564000
             }
           },
           {
@@ -86,7 +86,7 @@
             "name": "unknown",
             "result": {
               "status": "Skipped",
-              "duration": 245000
+              "duration": 253000
             }
           }
         ]
@@ -110,7 +110,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 544000
+              "duration": 622000
             }
           }
         ]
@@ -119,17 +119,17 @@
         "after": [
           {
             "result": {
-              "status": "Failed",
-              "duration": 12000,
-              "error_message": "Tag!"
+              "status": "Passed",
+              "duration": 3000
             }
           }
         ],
         "before": [
           {
             "result": {
-              "status": "Passed",
-              "duration": 7000
+              "status": "Failed",
+              "duration": 110000,
+              "error_message": "Tag!"
             }
           }
         ],
@@ -140,64 +140,11 @@
         "name": "rule 2 secs",
         "tags": [
           {
-            "name": "fail_after",
+            "name": "fail_before",
             "line": 14
           }
         ],
-        "steps": [
-          {
-            "keyword": "Given",
-            "line": 15,
-            "name": "2 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 73000
-            }
-          },
-          {
-            "keyword": "When",
-            "line": 16,
-            "name": "2 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 68000
-            }
-          },
-          {
-            "keyword": "Then",
-            "line": 17,
-            "name": "2 secs",
-            "result": {
-              "status": "Failed",
-              "duration": 616000,
-              "error_message": "Too much!"
-            }
-          }
-        ]
-      },
-      {
-        "keyword": "Background",
-        "type": "background",
-        "id": "basic/rule/2-secs",
-        "line": 14,
-        "name": "rule 2 secs",
-        "tags": [
-          {
-            "name": "fail_after",
-            "line": 14
-          }
-        ],
-        "steps": [
-          {
-            "keyword": "Given",
-            "line": 3,
-            "name": "1 sec",
-            "result": {
-              "status": "Passed",
-              "duration": 32000
-            }
-          }
-        ]
+        "steps": []
       }
     ]
   },
@@ -212,7 +159,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 5000
+              "duration": 2000
             }
           }
         ],
@@ -220,7 +167,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 9000
+              "duration": 10000
             }
           }
         ],
@@ -242,7 +189,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 38000
+              "duration": 24000
             }
           },
           {
@@ -251,7 +198,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 34000
+              "duration": 22000
             }
           },
           {
@@ -260,7 +207,7 @@
             "name": "unknown",
             "result": {
               "status": "Skipped",
-              "duration": 12000
+              "duration": 8000
             }
           }
         ]
@@ -284,7 +231,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 42000
+              "duration": 31000
             }
           }
         ]
@@ -332,8 +279,9 @@
         "after": [
           {
             "result": {
-              "status": "Passed",
-              "duration": 3000
+              "status": "Failed",
+              "duration": 14000,
+              "error_message": "Tag!"
             }
           }
         ],
@@ -354,6 +302,10 @@
           {
             "name": "tag",
             "line": 12
+          },
+          {
+            "name": "fail_after",
+            "line": 12
           }
         ],
         "steps": [
@@ -363,7 +315,7 @@
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 34000
+              "duration": 82000
             }
           },
           {
@@ -372,7 +324,7 @@
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 22000
+              "duration": 70000
             }
           },
           {
@@ -381,7 +333,7 @@
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 21000
+              "duration": 523000
             }
           }
         ]
@@ -390,8 +342,9 @@
         "after": [
           {
             "result": {
-              "status": "Passed",
-              "duration": 2000
+              "status": "Failed",
+              "duration": 12000,
+              "error_message": "Tag!"
             }
           }
         ],
@@ -412,6 +365,10 @@
           {
             "name": "tag",
             "line": 13
+          },
+          {
+            "name": "fail_after",
+            "line": 13
           }
         ],
         "steps": [
@@ -421,7 +378,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 29000
             }
           },
           {
@@ -439,7 +396,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 25000
+              "duration": 21000
             }
           }
         ]
@@ -448,8 +405,9 @@
         "after": [
           {
             "result": {
-              "status": "Passed",
-              "duration": 3000
+              "status": "Failed",
+              "duration": 12000,
+              "error_message": "Tag!"
             }
           }
         ],
@@ -457,7 +415,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 5000
+              "duration": 6000
             }
           }
         ],
@@ -470,6 +428,10 @@
           {
             "name": "tag",
             "line": 14
+          },
+          {
+            "name": "fail_after",
+            "line": 14
           }
         ],
         "steps": [
@@ -479,7 +441,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 28000
+              "duration": 32000
             }
           },
           {
@@ -488,7 +450,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 21000
+              "duration": 22000
             }
           },
           {
@@ -497,7 +459,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 21000
+              "duration": 22000
             }
           }
         ]
@@ -506,8 +468,9 @@
         "after": [
           {
             "result": {
-              "status": "Passed",
-              "duration": 2000
+              "status": "Failed",
+              "duration": 12000,
+              "error_message": "Tag!"
             }
           }
         ],
@@ -528,6 +491,10 @@
           {
             "name": "tag",
             "line": 15
+          },
+          {
+            "name": "fail_after",
+            "line": 15
           }
         ],
         "steps": [
@@ -546,7 +513,7 @@
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 21000
+              "duration": 22000
             }
           },
           {
@@ -555,7 +522,7 @@
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 21000
+              "duration": 26000
             }
           }
         ]
@@ -573,7 +540,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 3000
+              "duration": 2000
             }
           }
         ],
@@ -581,7 +548,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 5000
+              "duration": 6000
             }
           }
         ],
@@ -598,78 +565,25 @@
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 28000
+              "duration": 29000
             }
           },
           {
             "keyword": "When",
             "line": 6,
-            "name": "2 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 21000
-            }
-          },
-          {
-            "keyword": "Then",
-            "line": 7,
             "name": "2 secs",
             "result": {
               "status": "Passed",
               "duration": 22000
             }
-          }
-        ]
-      },
-      {
-        "after": [
-          {
-            "result": {
-              "status": "Passed",
-              "duration": 2000
-            }
-          }
-        ],
-        "before": [
-          {
-            "result": {
-              "status": "Passed",
-              "duration": 5000
-            }
-          }
-        ],
-        "keyword": "Scenario Outline",
-        "type": "scenario",
-        "id": "rule-outline/to-them-all/wait",
-        "line": 11,
-        "name": "To them all wait",
-        "tags": [],
-        "steps": [
-          {
-            "keyword": "Given",
-            "line": 5,
-            "name": "1 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 27000
-            }
-          },
-          {
-            "keyword": "When",
-            "line": 6,
-            "name": "1 secs",
-            "result": {
-              "status": "Passed",
-              "duration": 21000
-            }
           },
           {
             "keyword": "Then",
             "line": 7,
-            "name": "1 secs",
+            "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 21000
             }
           }
         ]
@@ -694,7 +608,7 @@
         "keyword": "Scenario Outline",
         "type": "scenario",
         "id": "rule-outline/to-them-all/wait",
-        "line": 12,
+        "line": 11,
         "name": "To them all wait",
         "tags": [],
         "steps": [
@@ -704,7 +618,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 29000
             }
           },
           {
@@ -713,7 +627,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 21000
+              "duration": 22000
             }
           },
           {
@@ -722,7 +636,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 21000
             }
           }
         ]
@@ -740,7 +654,60 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 5000
+              "duration": 6000
+            }
+          }
+        ],
+        "keyword": "Scenario Outline",
+        "type": "scenario",
+        "id": "rule-outline/to-them-all/wait",
+        "line": 12,
+        "name": "To them all wait",
+        "tags": [],
+        "steps": [
+          {
+            "keyword": "Given",
+            "line": 5,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 29000
+            }
+          },
+          {
+            "keyword": "When",
+            "line": 6,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 25000
+            }
+          },
+          {
+            "keyword": "Then",
+            "line": 7,
+            "name": "1 secs",
+            "result": {
+              "status": "Passed",
+              "duration": 22000
+            }
+          }
+        ]
+      },
+      {
+        "after": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 2000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 6000
             }
           }
         ],
@@ -757,7 +724,7 @@
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 29000
             }
           },
           {
@@ -766,7 +733,7 @@
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 23000
             }
           },
           {


### PR DESCRIPTION
Resolves #127


## Synopsis

For now `cucumber` output can't be parsed by default `CI` tools.



## Solution

Implement `writer::Json`



## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
