### PR TITLE
Implement `writer::AssertNormalized`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 - Support for [Cucumber Expressions] via `#[given(expr = ...)]`, `#[when(expr = ...)]` and `#[then(expr = ...)]` syntax. ([#157])
 - Support for custom parameters in [Cucumber Expressions] via `#[derive(cucumber::Parameter)]` macro. ([#168])
 - Merging tags from `Feature` and `Rule` with `Scenario` when filtering with `--tags` CLI option. ([#166])
+- `writer::AssertNormalized` in case you are sure, that incoming events are already `Normalized`. ([#182]) 
 
 ### Fixed
 
@@ -54,6 +55,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 [#168]: /../../pull/168
 [#172]: /../../pull/172
 [#178]: /../../pull/178
+[#182]: /../../pull/182
 [cef3d480]: /../../commit/cef3d480579190425461ddb04a1248675248351e
 [rev]: /../../commit/rev-full
 [0110-1]: https://llg.cubic.org/docs/junit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 - Support for [Cucumber Expressions] via `#[given(expr = ...)]`, `#[when(expr = ...)]` and `#[then(expr = ...)]` syntax. ([#157])
 - Support for custom parameters in [Cucumber Expressions] via `#[derive(cucumber::Parameter)]` macro. ([#168])
 - Merging tags from `Feature` and `Rule` with `Scenario` when filtering with `--tags` CLI option. ([#166])
-- `writer::AssertNormalized` in case you are sure, that incoming events are already `Normalized`. ([#182]) 
+- `writer::AssertNormalized` forcing `Normalized` implementation. ([#182]) 
 
 ### Fixed
 

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -133,12 +133,20 @@ pub trait Failure<World>: Writer<World> {
 /// Extension of [`Writer`] allowing its normalization and summarization.
 #[sealed]
 pub trait Ext: Sized {
-    /// Does nothing, but makes [`Writer`] [`Normalized`].
+    /// Asserts this [`Writer`] being [`Normalized`].
     ///
-    /// > ⚠️ __WARNING__: Should be used only in case you are sure, that
-    /// > incoming events will be in a [`Normalized`] order. For example in case
-    /// > [`runner::Basic::max_concurrent_scenarios()`][1] is set to `1`.
+    /// Technically is no-op, only forcing the [`Writer`] to become
+    /// [`Normalized`] despite it actually doesn't represent the one.
     ///
+    /// If you need a real normalization, use [`normalized()`] instead.
+    ///
+    /// > ⚠️ __WARNING__: Should be used only in case you are absolutely sure,
+    /// >                 that incoming events will be emitted in a
+    /// >                 [`Normalized`] order.
+    /// >                 For example, in case [`max_concurrent_scenarios()`][1]
+    /// >                 is set to `1`.
+    ///
+    /// [`normalized()`]: Ext::normalized
     /// [1]: crate::runner::Basic::max_concurrent_scenarios()
     #[must_use]
     fn assert_normalized(self) -> AssertNormalized<Self>;

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -41,7 +41,7 @@ pub use self::junit::JUnit;
 pub use self::{
     basic::{Basic, Coloring},
     fail_on_skipped::FailOnSkipped,
-    normalize::{Normalize, Normalized},
+    normalize::{AssertNormalized, Normalize, Normalized},
     repeat::Repeat,
     summarize::{Summarizable, Summarize},
     tee::Tee,
@@ -133,6 +133,16 @@ pub trait Failure<World>: Writer<World> {
 /// Extension of [`Writer`] allowing its normalization and summarization.
 #[sealed]
 pub trait Ext: Sized {
+    /// Does nothing, but makes [`Writer`] [`Normalized`].
+    ///
+    /// > ⚠️ __WARNING__: Should be used only in case you are sure, that
+    /// > incoming events will be in a [`Normalized`] order. For example in case
+    /// > [`runner::Basic::max_concurrent_scenarios()`][1] is set to `1`.
+    ///
+    /// [1]: crate::runner::Basic::max_concurrent_scenarios()
+    #[must_use]
+    fn assert_normalized(self) -> AssertNormalized<Self>;
+
     /// Wraps this [`Writer`] into a [`Normalize`]d version.
     ///
     /// See [`Normalize`] for more information.
@@ -227,6 +237,10 @@ pub trait Ext: Sized {
 
 #[sealed]
 impl<T> Ext for T {
+    fn assert_normalized(self) -> AssertNormalized<Self> {
+        AssertNormalized::new(self)
+    }
+
     fn normalized<W>(self) -> Normalize<W, Self> {
         Normalize::new(self)
     }

--- a/src/writer/normalize.rs
+++ b/src/writer/normalize.rs
@@ -189,21 +189,31 @@ pub trait Normalized {}
 
 impl<World, Writer> Normalized for Normalize<World, Writer> {}
 
-/// Wrapper for a [`Writer`] that does nothing, but implements [`Normalized`].
+/// Wrapper for a [`Writer`] asserting it being [`Normalized`].
 ///
-/// [1]: crate::runner::Basic::max_concurrent_scenarios()
+/// Technically is no-op, only forcing the [`Writer`] to become [`Normalized`]
+/// despite it actually doesn't represent the one.
+///
+/// > ⚠️ __WARNING__: Should be used only in case you are absolutely sure, that
+/// >                 incoming events will be emitted in a [`Normalized`] order.
+/// >                 For example, in case [`max_concurrent_scenarios()`][1] is
+/// >                 set to `1`.
+///
+/// [1]: crate::runner::Basic::max_concurrent_scenarios
 #[derive(Debug, Deref)]
 pub struct AssertNormalized<W: ?Sized>(W);
 
 impl<Writer> AssertNormalized<Writer> {
-    /// Creates a new [`AssertNormalized`] wrapper, which does nothing, but
-    /// implements [`Normalized`].
+    /// Creates a new no-op [`AssertNormalized`] wrapper forcing [`Normalized`]
+    /// implementation.
     ///
-    /// > ⚠️ __WARNING__: Should be used only in case you are sure, that
-    /// > incoming events will be in a [`Normalized`] order. For example in case
-    /// > [`runner::Basic::max_concurrent_scenarios()`][1] is set to `1`.
+    /// > ⚠️ __WARNING__: Should be used only in case you are absolutely sure,
+    /// >                 that incoming events will be emitted in a
+    /// >                 [`Normalized`] order.
+    /// >                 For example, in case [`max_concurrent_scenarios()`][1]
+    /// >                 is set to `1`.
     ///
-    /// [1]: crate::runner::Basic::max_concurrent_scenarios()
+    /// [1]: crate::runner::Basic::max_concurrent_scenarios
     #[must_use]
     pub const fn new(writer: Writer) -> Self {
         Self(writer)

--- a/src/writer/normalize.rs
+++ b/src/writer/normalize.rs
@@ -19,7 +19,7 @@ use linked_hash_map::LinkedHashMap;
 
 use crate::{
     event::{self, Metadata},
-    parser, writer, Event, Writer,
+    parser, writer, Event, World, Writer,
 };
 
 /// Wrapper for a [`Writer`] implementation for outputting events corresponding
@@ -188,6 +188,80 @@ impl<W, Wr: writer::NonTransforming> writer::NonTransforming
 pub trait Normalized {}
 
 impl<World, Writer> Normalized for Normalize<World, Writer> {}
+
+/// Wrapper for a [`Writer`] that does nothing, but implements [`Normalized`].
+///
+/// [1]: crate::runner::Basic::max_concurrent_scenarios()
+#[derive(Debug, Deref)]
+pub struct AssertNormalized<W: ?Sized>(W);
+
+impl<Writer> AssertNormalized<Writer> {
+    /// Creates a new [`AssertNormalized`] wrapper, which does nothing, but
+    /// implements [`Normalized`].
+    ///
+    /// > ⚠️ __WARNING__: Should be used only in case you are sure, that
+    /// > incoming events will be in a [`Normalized`] order. For example in case
+    /// > [`runner::Basic::max_concurrent_scenarios()`][1] is set to `1`.
+    ///
+    /// [1]: crate::runner::Basic::max_concurrent_scenarios()
+    #[must_use]
+    pub const fn new(writer: Writer) -> Self {
+        Self(writer)
+    }
+}
+
+#[async_trait(?Send)]
+impl<W: World, Wr: Writer<W> + ?Sized> Writer<W> for AssertNormalized<Wr> {
+    type Cli = Wr::Cli;
+
+    async fn handle_event(
+        &mut self,
+        event: parser::Result<Event<event::Cucumber<W>>>,
+        cli: &Self::Cli,
+    ) {
+        self.0.handle_event(event, cli).await;
+    }
+}
+
+#[async_trait(?Send)]
+impl<'val, W, Wr, Val> writer::Arbitrary<'val, W, Val> for AssertNormalized<Wr>
+where
+    W: World,
+    Val: 'val,
+    Wr: writer::Arbitrary<'val, W, Val> + ?Sized,
+{
+    async fn write(&mut self, val: Val)
+    where
+        'val: 'async_trait,
+    {
+        self.0.write(val).await;
+    }
+}
+
+impl<W, Wr> writer::Failure<W> for AssertNormalized<Wr>
+where
+    Wr: writer::Failure<W>,
+    Self: Writer<W>,
+{
+    fn failed_steps(&self) -> usize {
+        self.0.failed_steps()
+    }
+
+    fn parsing_errors(&self) -> usize {
+        self.0.parsing_errors()
+    }
+
+    fn hook_errors(&self) -> usize {
+        self.0.hook_errors()
+    }
+}
+
+impl<Wr: writer::NonTransforming> writer::NonTransforming
+    for AssertNormalized<Wr>
+{
+}
+
+impl<Writer> Normalized for AssertNormalized<Writer> {}
 
 /// Normalization queue for incoming events.
 ///

--- a/src/writer/summarize.rs
+++ b/src/writer/summarize.rs
@@ -10,7 +10,7 @@
 
 //! [`Writer`]-wrapper for collecting a summary of execution.
 
-use std::{array, borrow::Cow, collections::HashMap, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use derive_more::Deref;
@@ -501,7 +501,7 @@ impl Styles {
     /// Formats [`Stats`] for a terminal output.
     #[must_use]
     pub fn format_stats(&self, stats: Stats) -> Cow<'static, str> {
-        let formatted = array::IntoIter::new([
+        let formatted = [
             (stats.passed > 0)
                 .then(|| self.bold(self.ok(format!("{} passed", stats.passed))))
                 .unwrap_or_default(),
@@ -517,7 +517,8 @@ impl Styles {
                     self.bold(self.err(format!("{} failed", stats.failed)))
                 })
                 .unwrap_or_default(),
-        ])
+        ]
+        .into_iter()
         .filter(|s| !s.is_empty())
         .join(&self.bold(", "));
 


### PR DESCRIPTION
## Synopsis

Revealed from https://github.com/cucumber-rs/cucumber/issues/177#issuecomment-988606648


## Solution

Implement `writer::AssertNormalized`




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
