### PR TITLE
Replace structopt by clap (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 - Bump up [MSRV] to 1.57 for better error reporting in `const` assertions. ([cef3d480])
 - Switch to [`gherkin`] crate instead of [`gherkin_rust`]. ([rev])
 - Renamed `@allow_skipped` built-in tag to `@allow.skipped`. ([#181])
+- Switched CLI to `clap` from `structopt`. ([#188])
 
 ### Added
 
@@ -60,6 +61,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 [#178]: /../../pull/178
 [#181]: /../../pull/181
 [#182]: /../../pull/182
+[#188]: /../../pull/188
 [cef3d480]: /../../commit/cef3d480579190425461ddb04a1248675248351e
 [rev]: /../../commit/rev-full
 [0110-1]: https://llg.cubic.org/docs/junit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ timestamps = []
 [dependencies]
 async-trait = "0.1.40"
 atty = "0.2.14"
+clap = { version = "3.0.0-rc.7", features = ["derive"] }
 console = "0.15"
 derive_more = { version = "0.99.17", features = ["as_ref", "deref", "deref_mut", "display", "error", "from", "into"], default_features = false }
 either = "1.6"
@@ -50,7 +51,6 @@ linked-hash-map = "0.5.3"
 once_cell = { version = "1.8", features = ["parking_lot"] }
 regex = "1.5"
 sealed = "0.3"
-clap = { version = "3.0.0-rc.7", features = ["derive"]  }
 
 # "macros" feature dependencies.
 cucumber-codegen = { version = "0.11.0-dev", path = "./codegen", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ linked-hash-map = "0.5.3"
 once_cell = { version = "1.8", features = ["parking_lot"] }
 regex = "1.5"
 sealed = "0.3"
-structopt = "0.3.25"
+clap = { version = "3.0.0-rc.7", features = ["derive"]  }
 
 # "macros" feature dependencies.
 cucumber-codegen = { version = "0.11.0-dev", path = "./codegen", optional = true }

--- a/src/cucumber.rs
+++ b/src/cucumber.rs
@@ -20,13 +20,13 @@ use std::{
     path::Path,
 };
 
+use futures::{future::LocalBoxFuture, StreamExt as _};
+use regex::Regex;
+
 use crate::{
     cli, event, parser, runner, step, tag::Ext as _, writer, Event, Parser,
     Runner, ScenarioType, Step, World, Writer, WriterExt as _,
 };
-use clap::{Args, Parser as _};
-use futures::{future::LocalBoxFuture, StreamExt as _};
-use regex::Regex;
 
 /// Top-level [Cucumber] executor.
 ///
@@ -53,7 +53,7 @@ where
     P: Parser<I>,
     R: Runner<W>,
     Wr: Writer<W>,
-    Cli: Args,
+    Cli: clap::Args,
 {
     /// [`Parser`] sourcing [`Feature`]s for execution.
     ///
@@ -87,7 +87,7 @@ where
     P: Parser<I>,
     R: Runner<W>,
     Wr: Writer<W>,
-    Cli: Args,
+    Cli: clap::Args,
 {
     /// Creates a custom [`Cucumber`] executor with the provided [`Parser`],
     /// [`Runner`] and [`Writer`].
@@ -436,7 +436,7 @@ where
     P: Parser<I>,
     R: Runner<W>,
     Wr: Writer<W> + for<'val> writer::Arbitrary<'val, W, String>,
-    Cli: Args,
+    Cli: clap::Args,
 {
     /// Consider [`Skipped`] steps as [`Failed`] if their [`Scenario`] isn't
     /// marked with `@allow.skipped` tag.
@@ -626,7 +626,7 @@ where
     P: Parser<I>,
     R: Runner<W>,
     Wr: Writer<W> + writer::Normalized,
-    Cli: Args,
+    Cli: clap::Args,
 {
     /// Runs [`Cucumber`].
     ///
@@ -644,7 +644,7 @@ where
     /// using them inside [`Cucumber`].
     ///
     /// Also, any additional custom CLI options may be specified as a
-    /// [`Args`] deriving type, used as the last type parameter of
+    /// [`clap::Args`] deriving type, used as the last type parameter of
     /// [`cli::Opts`].
     ///
     /// > ⚠️ __WARNING__: Any CLI options of [`Parser`], [`Runner`], [`Writer`]
@@ -657,7 +657,6 @@ where
     /// # use std::{convert::Infallible, time::Duration};
     /// #
     /// # use async_trait::async_trait;
-    /// # use clap::{Args, Parser as _};
     /// # use cucumber::{cli, WorldInit};
     /// # use futures::FutureExt as _;
     /// # use tokio::time;
@@ -676,7 +675,7 @@ where
     /// #
     /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
-    /// #[derive(Args)]
+    /// #[derive(clap::Args)]
     /// struct CustomCli {
     ///     /// Additional time to wait in a before hook.
     ///     #[clap(
@@ -686,7 +685,7 @@ where
     ///     before_time: Option<Duration>,
     /// }
     ///
-    /// let cli = cli::Opts::<_, _, _, CustomCli>::parse();
+    /// let cli = cli::Opts::<_, _, _, CustomCli>::parsed();
     /// let time = cli.custom.before_time.unwrap_or_default();
     ///
     /// MyWorld::cucumber()
@@ -718,7 +717,7 @@ where
         cli: cli::Opts<P::Cli, R::Cli, Wr::Cli, CustomCli>,
     ) -> Cucumber<W, P, I, R, Wr, CustomCli>
     where
-        CustomCli: Args,
+        CustomCli: clap::Args,
     {
         let Cucumber {
             parser,
@@ -810,7 +809,7 @@ where
             runner: runner_cli,
             writer: writer_cli,
             ..
-        } = self.cli.unwrap_or_else(cli::Opts::<_, _, _, _>::parse);
+        } = self.cli.unwrap_or_else(cli::Opts::<_, _, _, _>::parsed);
 
         let filter = move |feat: &gherkin::Feature,
                            rule: Option<&gherkin::Rule>,
@@ -883,7 +882,7 @@ where
     P: Debug + Parser<I>,
     R: Debug + Runner<W>,
     Wr: Debug + Writer<W>,
-    Cli: Args,
+    Cli: clap::Args,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Cucumber")
@@ -953,7 +952,7 @@ where
     W: World,
     R: Runner<W>,
     Wr: Writer<W>,
-    Cli: Args,
+    Cli: clap::Args,
     I: AsRef<Path>,
 {
     /// Sets the provided language of [`gherkin`] files.
@@ -976,7 +975,7 @@ where
     W: World,
     P: Parser<I>,
     Wr: Writer<W>,
-    Cli: Args,
+    Cli: clap::Args,
     F: Fn(
             &gherkin::Feature,
             Option<&gherkin::Rule>,
@@ -1175,7 +1174,7 @@ where
     P: Parser<I>,
     R: Runner<W>,
     Wr: writer::Failure<W> + writer::Normalized,
-    Cli: Args,
+    Cli: clap::Args,
 {
     /// Runs [`Cucumber`].
     ///

--- a/src/cucumber.rs
+++ b/src/cucumber.rs
@@ -20,14 +20,13 @@ use std::{
     path::Path,
 };
 
-use futures::{future::LocalBoxFuture, StreamExt as _};
-use regex::Regex;
-use structopt::{StructOpt, StructOptInternal};
-
 use crate::{
     cli, event, parser, runner, step, tag::Ext as _, writer, Event, Parser,
     Runner, ScenarioType, Step, World, Writer, WriterExt as _,
 };
+use clap::{Args, Parser as _};
+use futures::{future::LocalBoxFuture, StreamExt as _};
+use regex::Regex;
 
 /// Top-level [Cucumber] executor.
 ///
@@ -54,7 +53,7 @@ where
     P: Parser<I>,
     R: Runner<W>,
     Wr: Writer<W>,
-    Cli: StructOpt,
+    Cli: Args,
 {
     /// [`Parser`] sourcing [`Feature`]s for execution.
     ///
@@ -88,7 +87,7 @@ where
     P: Parser<I>,
     R: Runner<W>,
     Wr: Writer<W>,
-    Cli: StructOpt,
+    Cli: Args,
 {
     /// Creates a custom [`Cucumber`] executor with the provided [`Parser`],
     /// [`Runner`] and [`Writer`].
@@ -437,7 +436,7 @@ where
     P: Parser<I>,
     R: Runner<W>,
     Wr: Writer<W> + for<'val> writer::Arbitrary<'val, W, String>,
-    Cli: StructOpt,
+    Cli: Args,
 {
     /// Consider [`Skipped`] steps as [`Failed`] if their [`Scenario`] isn't
     /// marked with `@allow.skipped` tag.
@@ -627,7 +626,7 @@ where
     P: Parser<I>,
     R: Runner<W>,
     Wr: Writer<W> + writer::Normalized,
-    Cli: StructOpt + StructOptInternal,
+    Cli: Args,
 {
     /// Runs [`Cucumber`].
     ///
@@ -645,7 +644,7 @@ where
     /// using them inside [`Cucumber`].
     ///
     /// Also, any additional custom CLI options may be specified as a
-    /// [`StructOpt`] deriving type, used as the last type parameter of
+    /// [`Args`] deriving type, used as the last type parameter of
     /// [`cli::Opts`].
     ///
     /// > ⚠️ __WARNING__: Any CLI options of [`Parser`], [`Runner`], [`Writer`]
@@ -658,9 +657,9 @@ where
     /// # use std::{convert::Infallible, time::Duration};
     /// #
     /// # use async_trait::async_trait;
+    /// # use clap::{Args, Parser as _};
     /// # use cucumber::{cli, WorldInit};
     /// # use futures::FutureExt as _;
-    /// # use structopt::StructOpt;
     /// # use tokio::time;
     /// #
     /// # #[derive(Debug, WorldInit)]
@@ -677,17 +676,17 @@ where
     /// #
     /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
-    /// #[derive(StructOpt)]
+    /// #[derive(Args)]
     /// struct CustomCli {
     ///     /// Additional time to wait in a before hook.
-    ///     #[structopt(
+    ///     #[clap(
     ///         long,
     ///         parse(try_from_str = humantime::parse_duration)
     ///     )]
     ///     before_time: Option<Duration>,
     /// }
     ///
-    /// let cli = cli::Opts::<_, _, _, CustomCli>::from_args();
+    /// let cli = cli::Opts::<_, _, _, CustomCli>::parse();
     /// let time = cli.custom.before_time.unwrap_or_default();
     ///
     /// MyWorld::cucumber()
@@ -719,7 +718,7 @@ where
         cli: cli::Opts<P::Cli, R::Cli, Wr::Cli, CustomCli>,
     ) -> Cucumber<W, P, I, R, Wr, CustomCli>
     where
-        CustomCli: StructOpt,
+        CustomCli: Args,
     {
         let Cucumber {
             parser,
@@ -811,7 +810,7 @@ where
             runner: runner_cli,
             writer: writer_cli,
             ..
-        } = self.cli.unwrap_or_else(cli::Opts::<_, _, _, _>::from_args);
+        } = self.cli.unwrap_or_else(cli::Opts::<_, _, _, _>::parse);
 
         let filter = move |feat: &gherkin::Feature,
                            rule: Option<&gherkin::Rule>,
@@ -884,7 +883,7 @@ where
     P: Debug + Parser<I>,
     R: Debug + Runner<W>,
     Wr: Debug + Writer<W>,
-    Cli: StructOpt,
+    Cli: Args,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Cucumber")
@@ -954,7 +953,7 @@ where
     W: World,
     R: Runner<W>,
     Wr: Writer<W>,
-    Cli: StructOpt,
+    Cli: Args,
     I: AsRef<Path>,
 {
     /// Sets the provided language of [`gherkin`] files.
@@ -977,7 +976,7 @@ where
     W: World,
     P: Parser<I>,
     Wr: Writer<W>,
-    Cli: StructOpt,
+    Cli: Args,
     F: Fn(
             &gherkin::Feature,
             Option<&gherkin::Rule>,
@@ -1176,7 +1175,7 @@ where
     P: Parser<I>,
     R: Runner<W>,
     Wr: writer::Failure<W> + writer::Normalized,
-    Cli: StructOpt + StructOptInternal,
+    Cli: Args,
 {
     /// Runs [`Cucumber`].
     ///

--- a/src/parser/basic.rs
+++ b/src/parser/basic.rs
@@ -18,12 +18,12 @@ use std::{
     vec,
 };
 
+use clap::Parser as ClapParser;
 use derive_more::{Display, Error};
 use futures::stream;
 use gherkin::GherkinEnv;
 use globwalk::{GlobWalker, GlobWalkerBuilder};
 use itertools::Itertools as _;
-use structopt::StructOpt;
 
 use crate::feature::Ext as _;
 
@@ -36,11 +36,11 @@ use super::{Error as ParseError, Parser};
     not(doc),
     allow(missing_docs, clippy::missing_docs_in_private_items)
 )]
-#[derive(Debug, StructOpt)]
+#[derive(Debug, ClapParser)]
 pub struct Cli {
     /// Glob pattern to look for feature files with. By default, looks for
     /// `*.feature`s in the path configured tests runner.
-    #[structopt(long = "input", short = "i", name = "glob")]
+    #[clap(long = "input", short = 'i', name = "glob")]
     pub features: Option<Walker>,
 }
 

--- a/src/parser/basic.rs
+++ b/src/parser/basic.rs
@@ -18,7 +18,6 @@ use std::{
     vec,
 };
 
-use clap::Parser as ClapParser;
 use derive_more::{Display, Error};
 use futures::stream;
 use gherkin::GherkinEnv;
@@ -36,7 +35,7 @@ use super::{Error as ParseError, Parser};
     not(doc),
     allow(missing_docs, clippy::missing_docs_in_private_items)
 )]
-#[derive(Debug, ClapParser)]
+#[derive(Debug, clap::Parser)]
 pub struct Cli {
     /// Glob pattern to look for feature files with. By default, looks for
     /// `*.feature`s in the path configured tests runner.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14,10 +14,10 @@
 
 pub mod basic;
 
-use clap::Args;
+use std::sync::Arc;
+
 use derive_more::{Display, Error};
 use futures::Stream;
-use std::sync::Arc;
 
 use crate::feature::ExpandExamplesError;
 
@@ -37,7 +37,7 @@ pub trait Parser<I> {
     /// [`cli::Empty`]: crate::cli::Empty
     /// [`Runner`]: crate::Runner
     /// [`Writer`]: crate::Writer
-    type Cli: Args;
+    type Cli: clap::Args;
 
     /// Output [`Stream`] of parsed [`Feature`]s.
     ///

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14,11 +14,10 @@
 
 pub mod basic;
 
-use std::sync::Arc;
-
+use clap::Args;
 use derive_more::{Display, Error};
 use futures::Stream;
-use structopt::StructOptInternal;
+use std::sync::Arc;
 
 use crate::feature::ExpandExamplesError;
 
@@ -38,10 +37,7 @@ pub trait Parser<I> {
     /// [`cli::Empty`]: crate::cli::Empty
     /// [`Runner`]: crate::Runner
     /// [`Writer`]: crate::Writer
-    // We do use `StructOptInternal` here only because `StructOpt::from_args()`
-    // requires exactly this trait bound. We don't touch any `StructOptInternal`
-    // details being a subject of instability.
-    type Cli: StructOptInternal + 'static;
+    type Cli: Args;
 
     /// Output [`Stream`] of parsed [`Feature`]s.
     ///

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -23,7 +23,6 @@ use std::{
     },
 };
 
-use clap::Parser as ClapParser;
 use futures::{
     channel::mpsc,
     future::{self, Either, LocalBoxFuture},
@@ -49,7 +48,7 @@ use crate::{
     not(doc),
     allow(clippy::missing_docs_in_private_items, missing_docs)
 )]
-#[derive(Clone, Copy, Debug, ClapParser)]
+#[derive(Clone, Copy, Debug, clap::Parser)]
 pub struct Cli {
     /// Number of scenarios to run concurrently. If not specified, uses the
     /// value configured in tests runner, or 64 by default.

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -23,6 +23,7 @@ use std::{
     },
 };
 
+use clap::Parser as ClapParser;
 use futures::{
     channel::mpsc,
     future::{self, Either, LocalBoxFuture},
@@ -34,7 +35,6 @@ use futures::{
 };
 use itertools::Itertools as _;
 use regex::{CaptureLocations, Regex};
-use structopt::StructOpt;
 
 use crate::{
     event::{self, HookType, Info},
@@ -49,11 +49,11 @@ use crate::{
     not(doc),
     allow(clippy::missing_docs_in_private_items, missing_docs)
 )]
-#[derive(Clone, Copy, Debug, StructOpt)]
+#[derive(Clone, Copy, Debug, ClapParser)]
 pub struct Cli {
     /// Number of scenarios to run concurrently. If not specified, uses the
     /// value configured in tests runner, or 64 by default.
-    #[structopt(long, short, name = "int")]
+    #[clap(long, short, name = "int")]
     pub concurrency: Option<usize>,
 }
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -16,8 +16,8 @@
 
 pub mod basic;
 
+use clap::Args;
 use futures::Stream;
-use structopt::StructOptInternal;
 
 use crate::{event, parser, Event};
 
@@ -65,12 +65,8 @@ pub trait Runner<World> {
     ///
     /// [`cli::Empty`]: crate::cli::Empty
     /// [`Parser`]: crate::Parser
-    /// [`StructOpt`]: structopt::StructOpt
     /// [`Writer`]: crate::Writer
-    // We do use `StructOptInternal` here only because `StructOpt::from_args()`
-    // requires exactly this trait bound. We don't touch any `StructOptInternal`
-    // details being a subject of instability.
-    type Cli: StructOptInternal;
+    type Cli: Args;
 
     /// Output events [`Stream`].
     type EventStream: Stream<

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -16,7 +16,6 @@
 
 pub mod basic;
 
-use clap::Args;
 use futures::Stream;
 
 use crate::{event, parser, Event};
@@ -66,7 +65,7 @@ pub trait Runner<World> {
     /// [`cli::Empty`]: crate::cli::Empty
     /// [`Parser`]: crate::Parser
     /// [`Writer`]: crate::Writer
-    type Cli: Args;
+    type Cli: clap::Args;
 
     /// Output events [`Stream`].
     type EventStream: Stream<

--- a/src/writer/basic.rs
+++ b/src/writer/basic.rs
@@ -19,10 +19,10 @@ use std::{
 };
 
 use async_trait::async_trait;
+use clap::Args;
 use derive_more::{Deref, DerefMut};
 use itertools::Itertools as _;
 use regex::CaptureLocations;
-use structopt::StructOpt;
 
 use crate::{
     cli::Colored,
@@ -43,15 +43,15 @@ use crate::{
     not(doc),
     allow(missing_docs, clippy::missing_docs_in_private_items)
 )]
-#[derive(Clone, Copy, Debug, StructOpt)]
+#[derive(Clone, Copy, Debug, Args)]
 pub struct Cli {
     /// Increased verbosity of an output: additionally outputs step's doc
     /// string (if present).
-    #[structopt(long, short)]
+    #[clap(long, short)]
     pub verbose: bool,
 
     /// Coloring policy for a console output.
-    #[structopt(long, name = "auto|always|never", default_value = "auto")]
+    #[clap(long, name = "auto|always|never", default_value = "auto")]
     pub color: Coloring,
 }
 

--- a/src/writer/basic.rs
+++ b/src/writer/basic.rs
@@ -19,7 +19,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use clap::Args;
 use derive_more::{Deref, DerefMut};
 use itertools::Itertools as _;
 use regex::CaptureLocations;
@@ -43,7 +42,7 @@ use crate::{
     not(doc),
     allow(missing_docs, clippy::missing_docs_in_private_items)
 )]
-#[derive(Clone, Copy, Debug, Args)]
+#[derive(clap::Args, Clone, Copy, Debug)]
 pub struct Cli {
     /// Increased verbosity of an output: additionally outputs step's doc
     /// string (if present).

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -26,8 +26,8 @@ pub mod summarize;
 pub mod tee;
 
 use async_trait::async_trait;
+use clap::Args;
 use sealed::sealed;
-use structopt::StructOptInternal;
 
 use crate::{event, parser, Event};
 
@@ -73,11 +73,7 @@ pub trait Writer<World> {
     /// [`cli::Empty`]: crate::cli::Empty
     /// [`Parser`]: crate::Parser
     /// [`Runner`]: crate::Runner
-    /// [`StructOpt`]: structopt::StructOpt
-    // We do use `StructOptInternal` here only because `StructOpt::from_args()`
-    // requires exactly this trait bound. We don't touch any `StructOptInternal`
-    // details being a subject of instability.
-    type Cli: StructOptInternal;
+    type Cli: Args;
 
     /// Handles the given [`Cucumber`] event.
     ///

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -26,7 +26,6 @@ pub mod summarize;
 pub mod tee;
 
 use async_trait::async_trait;
-use clap::Args;
 use sealed::sealed;
 
 use crate::{event, parser, Event};
@@ -73,7 +72,7 @@ pub trait Writer<World> {
     /// [`cli::Empty`]: crate::cli::Empty
     /// [`Parser`]: crate::Parser
     /// [`Runner`]: crate::Runner
-    type Cli: Args;
+    type Cli: clap::Args;
 
     /// Handles the given [`Cucumber`] event.
     ///

--- a/tests/wait.rs
+++ b/tests/wait.rs
@@ -1,16 +1,16 @@
 use std::{convert::Infallible, panic::AssertUnwindSafe, time::Duration};
 
 use async_trait::async_trait;
+use clap::{Args, Parser as _};
 use cucumber::{cli, given, then, when, Parameter, WorldInit};
 use derive_more::{Deref, FromStr};
 use futures::FutureExt as _;
-use structopt::StructOpt;
 use tokio::time;
 
-#[derive(StructOpt)]
+#[derive(Args)]
 struct CustomCli {
     /// Additional time to wait in before and after hooks.
-    #[structopt(
+    #[clap(
         long,
         default_value = "10ms",
         parse(try_from_str = humantime::parse_duration)
@@ -20,7 +20,7 @@ struct CustomCli {
 
 #[tokio::main]
 async fn main() {
-    let cli = cli::Opts::<_, _, _, CustomCli>::from_args();
+    let cli = cli::Opts::<_, _, _, CustomCli>::parse();
 
     let res = World::cucumber()
         .before(move |_, _, _, w| {

--- a/tests/wait.rs
+++ b/tests/wait.rs
@@ -1,13 +1,12 @@
 use std::{convert::Infallible, panic::AssertUnwindSafe, time::Duration};
 
 use async_trait::async_trait;
-use clap::{Args, Parser as _};
 use cucumber::{cli, given, then, when, Parameter, WorldInit};
 use derive_more::{Deref, FromStr};
 use futures::FutureExt as _;
 use tokio::time;
 
-#[derive(Args)]
+#[derive(cli::Args)]
 struct CustomCli {
     /// Additional time to wait in before and after hooks.
     #[clap(
@@ -20,7 +19,7 @@ struct CustomCli {
 
 #[tokio::main]
 async fn main() {
-    let cli = cli::Opts::<_, _, _, CustomCli>::parse();
+    let cli = cli::Opts::<_, _, _, CustomCli>::parsed();
 
     let res = World::cucumber()
         .before(move |_, _, _, w| {


### PR DESCRIPTION
This pull request is a draft, waiting for the official release of clap v3. However, if needed, It can already be reviewed as the api shouldn't drastically change.

The doc comments on top of structs deriving `clap::Args` or `clap::Parser` is still an issue with Clap v3. So I let the workaround in place.

Closes #155 