### PR TITLE
Fix `writer:: Summarize` ignoring `Coloring` options (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 - Bump up [MSRV] to 1.57 for better error reporting in `const` assertions. ([cef3d480])
 - Switch to [`gherkin`] crate instead of [`gherkin_rust`]. ([rev])
 - Renamed `@allow_skipped` built-in tag to `@allow.skipped`. ([#181])
-- Add `cli::Colored` trait to propagate `Coloring` to the outer `Writer`s. ([#189])
 
 ### Added
 
@@ -36,7 +35,8 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 - Support for [Cucumber Expressions] via `#[given(expr = ...)]`, `#[when(expr = ...)]` and `#[then(expr = ...)]` syntax. ([#157])
 - Support for custom parameters in [Cucumber Expressions] via `#[derive(cucumber::Parameter)]` macro. ([#168])
 - Merging tags from `Feature` and `Rule` with `Scenario` when filtering with `--tags` CLI option. ([#166])
-- `writer::AssertNormalized` forcing `Normalized` implementation. ([#182]) 
+- `writer::AssertNormalized` forcing `Normalized` implementation. ([#182])
+- `cli::Colored` trait for propagating `Coloring` to arbitrary `Writer`s. ([#189])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 - Bump up [MSRV] to 1.57 for better error reporting in `const` assertions. ([cef3d480])
 - Switch to [`gherkin`] crate instead of [`gherkin_rust`]. ([rev])
 - Renamed `@allow_skipped` built-in tag to `@allow.skipped`. ([#181])
+- Add `cli::Colored` trait to propagate `Coloring` to the outer `Writer`s. ([#189])
 
 ### Added
 
@@ -42,6 +43,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 - Template regex in `Scenario Outline` expansion from `<(\S+)>` to `<([^>\s]+)>`. ([#163])
 - Multiple `Examples` in `Scenario Outline`. ([#165], [#164])
 - Docstring and name expansion in `Scenario Outline`. ([#178], [#172])
+- `writer::Summarized` ignoring `Coloring` options. ([#189], [#188])
 
 [#147]: /../../pull/147
 [#151]: /../../pull/151

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -149,6 +149,20 @@ where
     pub custom: Custom,
 }
 
+/// Indication whether a [`Writer`] using CLI options supports colored output.
+///
+/// [`Writer`]: crate::Writer
+pub trait Colored {
+    /// Returns [`Coloring`] indicating whether a [`Writer`] using CLI options
+    /// supports colored output or not.
+    ///
+    /// [`Writer`]: crate::Writer
+    #[must_use]
+    fn coloring(&self) -> Coloring {
+        Coloring::Never
+    }
+}
+
 // Workaround for overwritten doc-comments.
 // https://github.com/TeXitoi/structopt/issues/333#issuecomment-712265332
 #[cfg_attr(doc, doc = "Empty CLI options.")]
@@ -164,6 +178,8 @@ pub struct Empty {
     #[structopt(skip)]
     skipped: (),
 }
+
+impl Colored for Empty {}
 
 // Workaround for overwritten doc-comments.
 // https://github.com/TeXitoi/structopt/issues/333#issuecomment-712265332
@@ -281,29 +297,13 @@ impl<L: StructOpt, R: StructOpt> Compose<L, R> {
     }
 }
 
-/// Indicates, whether [`Writer`] using CLI options supports colored output.
-///
-/// [`Writer`]: crate::Writer
-pub trait Colored {
-    /// Returns [`Coloring`] indicating, whether [`Writer`] using CLI options
-    /// supports colored output or not.
-    ///
-    /// [`Writer`]: crate::Writer
-    #[must_use]
-    fn coloring(&self) -> Coloring {
-        Coloring::Never
-    }
-}
-
-impl Colored for Empty {}
-
 impl<L, R> Colored for Compose<L, R>
 where
     L: Colored + StructOpt,
     R: Colored + StructOpt,
 {
     fn coloring(&self) -> Coloring {
-        // Basically, founds "maximum" Coloring of the CLI options.
+        // Basically, founds "maximum" `Coloring` of CLI options.
         match (self.left.coloring(), self.right.coloring()) {
             (Coloring::Always, _) | (_, Coloring::Always) => Coloring::Always,
             (Coloring::Auto, _) | (_, Coloring::Auto) => Coloring::Auto,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -282,6 +282,8 @@ impl<L: StructOpt, R: StructOpt> Compose<L, R> {
 }
 
 /// Indicates, whether [`Writer`] using CLI options supports colored output.
+///
+/// [`Writer`]: crate::Writer
 pub trait Colored {
     /// Returns [`Coloring`] indicating, whether [`Writer`] using CLI options
     /// supports colored output or not.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -285,6 +285,8 @@ impl<L: StructOpt, R: StructOpt> Compose<L, R> {
 pub trait Colored {
     /// Returns [`Coloring`] indicating, whether [`Writer`] using CLI options
     /// supports colored output or not.
+    ///
+    /// [`Writer`]: crate::Writer
     #[must_use]
     fn coloring(&self) -> Coloring {
         Coloring::Never

--- a/src/writer/basic.rs
+++ b/src/writer/basic.rs
@@ -25,6 +25,7 @@ use regex::CaptureLocations;
 use structopt::StructOpt;
 
 use crate::{
+    cli::Colored,
     event::{self, Info},
     parser,
     writer::{
@@ -52,6 +53,12 @@ pub struct Cli {
     /// Coloring policy for a console output.
     #[structopt(long, name = "auto|always|never", default_value = "auto")]
     pub color: Coloring,
+}
+
+impl Colored for Cli {
+    fn coloring(&self) -> Coloring {
+        self.color
+    }
 }
 
 /// Possible policies of a [`console`] output coloring.
@@ -221,11 +228,7 @@ impl<Out: io::Write> Basic<Out> {
         if cli.verbose {
             self.verbose = true;
         }
-        match cli.color {
-            Coloring::Auto => {}
-            Coloring::Always => self.styles.is_present = true,
-            Coloring::Never => self.styles.is_present = false,
-        }
+        self.styles.apply_coloring(cli.color);
     }
 
     /// Clears last `n` lines if [`Coloring`] is enabled.

--- a/src/writer/out.rs
+++ b/src/writer/out.rs
@@ -15,6 +15,8 @@ use std::{borrow::Cow, io, str};
 use console::Style;
 use derive_more::{Deref, DerefMut, Display, From, Into};
 
+use super::Coloring;
+
 /// [`Style`]s for terminal output.
 #[derive(Debug)]
 pub struct Styles {
@@ -56,6 +58,15 @@ impl Styles {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Applies [`Coloring`] from the CLI options.
+    pub fn apply_coloring(&mut self, color: Coloring) {
+        match color {
+            Coloring::Auto => {}
+            Coloring::Always => self.is_present = true,
+            Coloring::Never => self.is_present = false,
+        }
     }
 
     /// If terminal is present colors `input` with [`Styles::ok`] color or

--- a/src/writer/out.rs
+++ b/src/writer/out.rs
@@ -60,7 +60,7 @@ impl Styles {
         Self::default()
     }
 
-    /// Applies [`Coloring`] from the CLI options.
+    /// Applies the given [`Coloring`] to these [`Styles`].
     pub fn apply_coloring(&mut self, color: Coloring) {
         match color {
             Coloring::Auto => {}

--- a/src/writer/summarize.rs
+++ b/src/writer/summarize.rs
@@ -206,6 +206,7 @@ where
 
         if let State::FinishedButNotOutput = self.state {
             self.state = State::FinishedAndOutput;
+
             let mut styles = Styles::new();
             styles.apply_coloring(cli.coloring());
             self.writer.write(styles.summary(self)).await;

--- a/src/writer/summarize.rs
+++ b/src/writer/summarize.rs
@@ -17,6 +17,7 @@ use derive_more::Deref;
 use itertools::Itertools as _;
 
 use crate::{
+    cli::Colored,
     event, parser,
     writer::{self, out::Styles},
     Event, World, Writer,
@@ -165,6 +166,7 @@ impl<W, Wr> Writer<W> for Summarize<Wr>
 where
     W: World,
     Wr: for<'val> writer::Arbitrary<'val, W, String> + Summarizable,
+    Wr::Cli: Colored,
 {
     type Cli = Wr::Cli;
 
@@ -204,7 +206,9 @@ where
 
         if let State::FinishedButNotOutput = self.state {
             self.state = State::FinishedAndOutput;
-            self.writer.write(Styles::new().summary(self)).await;
+            let mut styles = Styles::new();
+            styles.apply_coloring(cli.coloring());
+            self.writer.write(styles.summary(self)).await;
         }
     }
 }


### PR DESCRIPTION
Resolves #186

## Synopsis

For now `writer::Summarize` ignores `Coloring` options. 


## Solution

Introduce `cli::Colored` trait to propagate `Coloring` to the outer `Writer`s.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
