### PR TITLE
Fix `fail_on_skipped` for `Background` steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 ### Fixed
 
-- Skipped `Background` steps don't fail with `FailOnSkipped` writer. ([#199], [#198])
+- Skipped `Background` steps not failing in `writer::FailOnSkipped`. ([#199], [#198])
 
-[#198]: /../../pull/198
+[#198]: /../../issues/198
 [#199]: /../../pull/199
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 
 
+## [0.11.2] · 2022-01-??
+[0.11.2]: /../../tree/v0.11.2
+
+[Diff](/../../compare/v0.11.1...v0.11.2) | [Milestone](/../../milestone/7)
+
+### Fixed
+
+- Skipped `Background` steps don't fail with `FailOnSkipped` writer. ([#199], [#198])
+
+[#198]: /../../pull/198
+[#199]: /../../pull/199
+
+
+
+
 ## [0.11.1] · 2022-01-07
 [0.11.1]: /../../tree/v0.11.1
 

--- a/src/cucumber.rs
+++ b/src/cucumber.rs
@@ -438,8 +438,8 @@ where
     Wr: Writer<W> + for<'val> writer::Arbitrary<'val, W, String>,
     Cli: clap::Args,
 {
-    /// Consider [`Skipped`] steps as [`Failed`] if their [`Scenario`] isn't
-    /// marked with `@allow.skipped` tag.
+    /// Consider [`Skipped`] [`Background`] or regular [`Step`]s as [`Failed`]
+    /// if their [`Scenario`] isn't marked with `@allow.skipped` tag.
     ///
     /// It's useful option for ensuring that all the steps were covered.
     ///
@@ -502,9 +502,11 @@ where
     ///     Then the dog is not hungry
     /// ```
     ///
+    /// [`Background`]: gherkin::Background
     /// [`Failed`]: crate::event::Step::Failed
     /// [`Scenario`]: gherkin::Scenario
     /// [`Skipped`]: crate::event::Step::Skipped
+    /// [`Step`]: gherkin::Step
     #[must_use]
     pub fn fail_on_skipped(
         self,
@@ -519,8 +521,8 @@ where
         }
     }
 
-    /// Consider [`Skipped`] steps as [`Failed`] if the given `filter` predicate
-    /// returns `true`.
+    /// Consider [`Skipped`] [`Background`] or regular [`Step`]s as [`Failed`]
+    /// if the given `filter` predicate returns `true`.
     ///
     /// # Example
     ///
@@ -594,9 +596,11 @@ where
     ///     Then the dog is not hungry
     /// ```
     ///
+    /// [`Background`]: gherkin::Background
     /// [`Failed`]: crate::event::Step::Failed
     /// [`Scenario`]: gherkin::Scenario
     /// [`Skipped`]: crate::event::Step::Skipped
+    /// [`Step`]: gherkin::Step
     #[must_use]
     pub fn fail_on_skipped_with<Filter>(
         self,

--- a/src/writer/fail_on_skipped.rs
+++ b/src/writer/fail_on_skipped.rs
@@ -93,6 +93,10 @@ where
                     f,
                     Feature::Scenario(sc, Scenario::Step(st, Step::Skipped)),
                 ) => map_failed(f, None, sc, st),
+                Cucumber::Feature(
+                    f,
+                    Feature::Scenario(sc, Scenario::Background(st, Step::Skipped)),
+                ) => map_failed(f, None, sc, st),
                 Cucumber::Started
                 | Cucumber::Feature(..)
                 | Cucumber::Finished => ev,

--- a/src/writer/fail_on_skipped.rs
+++ b/src/writer/fail_on_skipped.rs
@@ -70,7 +70,16 @@ where
             Cucumber, Feature, Rule, Scenario, Step, StepError::Panic,
         };
 
-        let map_failed = |f: Arc<_>, r: Option<Arc<_>>, sc: Arc<_>, st: _| {
+        let map_failed_bg = |f: Arc<_>, r: Option<Arc<_>>, sc: Arc<_>, st: _| {
+            let ev = if (self.should_fail)(&f, r.as_deref(), &sc) {
+                Step::Failed(None, None, Panic(Arc::new("not allowed to skip")))
+            } else {
+                Step::Skipped
+            };
+
+            Cucumber::scenario(f, r, sc, Scenario::Background(st, ev))
+        };
+        let map_failed_step = |f: Arc<_>, r: Option<Arc<_>>, sc: Arc<_>, st: _| {
             let ev = if (self.should_fail)(&f, r.as_deref(), &sc) {
                 Step::Failed(None, None, Panic(Arc::new("not allowed to skip")))
             } else {
@@ -86,17 +95,24 @@ where
                     f,
                     Feature::Rule(
                         r,
-                        Rule::Scenario(sc, Scenario::Step(st, Step::Skipped)),
+                        Rule::Scenario(sc, Scenario::Background(st, Step::Skipped)),
                     ),
-                ) => map_failed(f, Some(r), sc, st),
-                Cucumber::Feature(
-                    f,
-                    Feature::Scenario(sc, Scenario::Step(st, Step::Skipped)),
-                ) => map_failed(f, None, sc, st),
+                ) => map_failed_bg(f, Some(r), sc, st),
                 Cucumber::Feature(
                     f,
                     Feature::Scenario(sc, Scenario::Background(st, Step::Skipped)),
-                ) => map_failed(f, None, sc, st),
+                ) => map_failed_bg(f, None, sc, st),
+                Cucumber::Feature(
+                    f,
+                    Feature::Rule(
+                        r,
+                        Rule::Scenario(sc, Scenario::Step(st, Step::Skipped)),
+                    ),
+                ) => map_failed_step(f, Some(r), sc, st),
+                Cucumber::Feature(
+                    f,
+                    Feature::Scenario(sc, Scenario::Step(st, Step::Skipped)),
+                ) => map_failed_step(f, None, sc, st),
                 Cucumber::Started
                 | Cucumber::Feature(..)
                 | Cucumber::Finished => ev,

--- a/src/writer/fail_on_skipped.rs
+++ b/src/writer/fail_on_skipped.rs
@@ -70,7 +70,7 @@ where
             Cucumber, Feature, Rule, Scenario, Step, StepError::Panic,
         };
 
-        let map_failed_bg = |f: Arc<_>, r: Option<Arc<_>>, sc: Arc<_>, st: _| {
+        let map_failed_bg = |f: Arc<_>, r: Option<_>, sc: Arc<_>, st: _| {
             let ev = if (self.should_fail)(&f, r.as_deref(), &sc) {
                 Step::Failed(None, None, Panic(Arc::new("not allowed to skip")))
             } else {
@@ -79,7 +79,7 @@ where
 
             Cucumber::scenario(f, r, sc, Scenario::Background(st, ev))
         };
-        let map_failed_step = |f: Arc<_>, r: Option<Arc<_>>, sc: Arc<_>, st: _| {
+        let map_failed_step = |f: Arc<_>, r: Option<_>, sc: Arc<_>, st: _| {
             let ev = if (self.should_fail)(&f, r.as_deref(), &sc) {
                 Step::Failed(None, None, Panic(Arc::new("not allowed to skip")))
             } else {
@@ -95,12 +95,18 @@ where
                     f,
                     Feature::Rule(
                         r,
-                        Rule::Scenario(sc, Scenario::Background(st, Step::Skipped)),
+                        Rule::Scenario(
+                            sc,
+                            Scenario::Background(st, Step::Skipped),
+                        ),
                     ),
                 ) => map_failed_bg(f, Some(r), sc, st),
                 Cucumber::Feature(
                     f,
-                    Feature::Scenario(sc, Scenario::Background(st, Step::Skipped)),
+                    Feature::Scenario(
+                        sc,
+                        Scenario::Background(st, Step::Skipped),
+                    ),
                 ) => map_failed_bg(f, None, sc, st),
                 Cucumber::Feature(
                     f,

--- a/src/writer/fail_on_skipped.rs
+++ b/src/writer/fail_on_skipped.rs
@@ -70,22 +70,19 @@ where
             Cucumber, Feature, Rule, Scenario, Step, StepError::Panic,
         };
 
-        let map_failed_bg = |f: Arc<_>, r: Option<_>, sc: Arc<_>, st: _| {
-            let ev = if (self.should_fail)(&f, r.as_deref(), &sc) {
+        let map_failed = |f: &Arc<_>, r: &Option<_>, sc: &Arc<_>| {
+            if (self.should_fail)(f, r.as_deref(), sc) {
                 Step::Failed(None, None, Panic(Arc::new("not allowed to skip")))
             } else {
                 Step::Skipped
-            };
-
+            }
+        };
+        let map_failed_bg = |f: Arc<_>, r: Option<_>, sc: Arc<_>, st: _| {
+            let ev = map_failed(&f, &r, &sc);
             Cucumber::scenario(f, r, sc, Scenario::Background(st, ev))
         };
         let map_failed_step = |f: Arc<_>, r: Option<_>, sc: Arc<_>, st: _| {
-            let ev = if (self.should_fail)(&f, r.as_deref(), &sc) {
-                Step::Failed(None, None, Panic(Arc::new("not allowed to skip")))
-            } else {
-                Step::Skipped
-            };
-
+            let ev = map_failed(&f, &r, &sc);
             Cucumber::scenario(f, r, sc, Scenario::Step(st, ev))
         };
 


### PR DESCRIPTION
Resolve #198 by including `Background` steps into the function that converts `Skipped` steps into `Failed` ones.