### PR TITLE
Remove leading and trailing quotes for `cucumber-expressions` `string` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 ### Fixed
 
 - Book examples failing on Windows. ([#202], [#200])
+- Remove leading and trailing quotes for `cucumber-expressions` `string` parameter ([#203], [cucumber-rs/cucumber-expressions#7])
 
 [#200]: /../../issues/200
 [#202]: /../../pull/202
+[#203]: /../../pull/203
+[cucumber-rs/cucumber-expressions#7]: https://github.com/cucumber-rs/cucumber-expressions/issues/7
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ sealed = "0.4"
 
 # "macros" feature dependencies.
 cucumber-codegen = { version = "0.11", path = "./codegen", optional = true }
-cucumber-expressions = { version = "0.1", features = ["into-regex"], optional = true }
+cucumber-expressions = { git = "https://github.com/cucumber-rs/cucumber-expressions", branch = "7-add-parameter-id", features = ["into-regex"], optional = true }
 inventory = { version = "0.2", optional = true }
 
 # "output-json" feature dependencies.

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["/tests/"]
 proc-macro = true
 
 [dependencies]
-cucumber-expressions = { version = "0.1", features = ["into-regex"] }
+cucumber-expressions = { git = "https://github.com/cucumber-rs/cucumber-expressions", branch = "7-add-parameter-id", features = ["into-regex"] }
 inflections = "1.1"
 itertools = "0.10"
 proc-macro2 = "1.0.28"

--- a/codegen/tests/example.rs
+++ b/codegen/tests/example.rs
@@ -82,9 +82,9 @@ fn test_return_result_read(
     what: String,
 ) -> io::Result<()> {
     let mut path = w.dir.path().to_path_buf();
-    path.push(filename.trim_matches('\''));
+    path.push(filename);
 
-    assert_eq!(what.trim_matches('"'), fs::read_to_string(path)?);
+    assert_eq!(what, fs::read_to_string(path)?);
 
     Ok(())
 }


### PR DESCRIPTION
Resolves https://github.com/cucumber-rs/cucumber-expressions/issues/7

## Synopsis

Currently `cucumber-expresions` `string` parameter regex group leaves quotes.


## Solution

Add `string_<id>` name to a string parameter (https://github.com/cucumber-rs/cucumber-expressions/pull/8) regex capture groups and handle it as a special case in `cucumber-codegen` crate.



## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [ ] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
