### PR TITLE
Pass the `World` to after hook even if `Step` has failed (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 
 
-## [0.13.0] · ???
-[0.13.0]: /../../tree/v0.13.0
+## [0.12.2] · ???
+[0.12.2]: /../../tree/v0.12.2
 
-[Diff](/../../compare/v0.12.1...v0.13.0)
+[Diff](/../../compare/v0.12.1...v0.12.2)
 
-### BC Breaks
+### Changed
 
 - [`Cucumber::after`][after_hook] now gets the `World` instance even if a `Step` or `Hook` before it has failed. ([#209], [#207])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 ### BC Breaks
 
-- [`Cucumber::after`][after_hook] now gets the `World` instance even if a `Step` before it has failed, but accepts a shared reference to it instance instead of a mutable one. ([#209], [#207])
+- [`Cucumber::after`][after_hook] now gets the `World` instance even if a `Step` or `Hook` before it has failed. ([#209], [#207])
 
 [#207]: /../../issues/207
 [#209]: /../../pull/209

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,18 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 
 
-## [0.12.2] · ???
+## [0.12.2] · 2022-???
 [0.12.2]: /../../tree/v0.12.2
 
 [Diff](/../../compare/v0.12.1...v0.12.2)
 
 ### Changed
 
-- [`Cucumber::after`][after_hook] now gets the `World` instance even if a `Step` or `Hook` before it has failed. ([#209], [#207])
+- [`Cucumber::after`][0122-1] now gets the `World` instance even if some `Step` or a `Hook` before it has failed. ([#209], [#207])
 
 [#207]: /../../issues/207
 [#209]: /../../pull/209
-[after_hook]: https://docs.rs/cucumber/latest/cucumber/struct.Cucumber.html#method.after
+[0122-1]: https://docs.rs/cucumber/0.12.2/cucumber/struct.Cucumber.html#method.after
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 
 
+## [0.13.0] · ???
+[0.13.0]: /../../tree/v0.13.0
+
+[Diff](/../../compare/v0.12.1...v0.13.0)
+
+### BC Breaks
+
+- [`Cucumber::after`][after_hook] now gets the `World` instance even if a `Step` before it has failed, but accepts a shared reference to it instance instead of a mutable one. ([#209], [#207])
+
+[#207]: /../../issues/207
+[#209]: /../../pull/209
+[after_hook]: https://docs.rs/cucumber/latest/cucumber/struct.Cucumber.html#method.after
+
+
+
+
 ## [0.12.1] · 2022-03-09
 [0.12.1]: /../../tree/v0.12.1
 
@@ -27,7 +43,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 ### BC Breaks
 
-- `step::Context::matches` now containes regex capturing group names in addition to captured values. ([#204])
+- `step::Context::matches` now contains regex capturing group names in addition to captured values. ([#204])
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,10 @@ harness = false
 name = "wait"
 harness = false
 
+[[test]]
+name = "after_hook"
+harness = false
+
 [workspace]
 members = ["codegen"]
 exclude = ["book/tests"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,10 @@ tempfile = "3.2"
 tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "time"] }
 
 [[test]]
+name = "after_hook"
+harness = false
+
+[[test]]
 name = "json"
 required-features = ["output-json"]
 harness = false
@@ -83,10 +87,6 @@ harness = false
 
 [[test]]
 name = "wait"
-harness = false
-
-[[test]]
-name = "after_hook"
 harness = false
 
 [workspace]

--- a/src/cucumber.rs
+++ b/src/cucumber.rs
@@ -997,7 +997,7 @@ where
             &'a gherkin::Feature,
             Option<&'a gherkin::Rule>,
             &'a gherkin::Scenario,
-            Option<&'a W>,
+            Option<&'a mut W>,
         ) -> LocalBoxFuture<'a, ()>
         + 'static,
 {
@@ -1108,7 +1108,7 @@ where
                 &'a gherkin::Feature,
                 Option<&'a gherkin::Rule>,
                 &'a gherkin::Scenario,
-                Option<&'a W>,
+                Option<&'a mut W>,
             ) -> LocalBoxFuture<'a, ()>
             + 'static,
     {

--- a/src/cucumber.rs
+++ b/src/cucumber.rs
@@ -997,7 +997,7 @@ where
             &'a gherkin::Feature,
             Option<&'a gherkin::Rule>,
             &'a gherkin::Scenario,
-            Option<&'a mut W>,
+            Option<&'a W>,
         ) -> LocalBoxFuture<'a, ()>
         + 'static,
 {
@@ -1091,12 +1091,7 @@ where
     /// [`Step`]s, even after [`Skipped`] of [`Failed`] [`Step`]s.
     ///
     /// Last `World` argument is supplied to the function, in case it was
-    /// initialized before by running [`before`] hook or any non-failed
-    /// [`Step`]. In case the last [`Scenario`]'s [`Step`] failed, we want to
-    /// return event with an exact `World` state. Also, we don't want to impose
-    /// additional [`Clone`] bounds on `World`, so the only option left is to
-    /// pass [`None`] to the function.
-    ///
+    /// initialized before by running [`before`] hook or any [`Step`].
     ///
     /// [`before`]: Self::before()
     /// [`Failed`]: event::Step::Failed
@@ -1113,7 +1108,7 @@ where
                 &'a gherkin::Feature,
                 Option<&'a gherkin::Rule>,
                 &'a gherkin::Scenario,
-                Option<&'a mut W>,
+                Option<&'a W>,
             ) -> LocalBoxFuture<'a, ()>
             + 'static,
     {

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -13,7 +13,6 @@
 use std::{
     cmp,
     collections::HashMap,
-    convert::identity,
     fmt, mem,
     ops::ControlFlow,
     panic::{self, AssertUnwindSafe},
@@ -102,13 +101,77 @@ pub type AfterHookFn<World> = for<'a> fn(
     &'a gherkin::Feature,
     Option<&'a gherkin::Rule>,
     &'a gherkin::Scenario,
-    Option<&'a World>,
+    Option<&'a mut World>,
 ) -> LocalBoxFuture<'a, ()>;
 
 /// Alias for a failed [`Scenario`].
 ///
 /// [`Scenario`]: gherkin::Scenario
 type Failed = bool;
+
+/// Failure encountered during execution of [`HookType::Before`] or [`Step`].
+/// See [`Self::emit_failed_events()`] for more info.
+///
+/// [`Step`]: gherkin::Step
+enum ExecutionFailure<World> {
+    /// [`HookType::Before`] panicked.
+    BeforeHookPanicked {
+        /// [`World`] at the time [`HookType::Before`] has panicked.
+        world: Option<World>,
+
+        /// [`catch_unwind()`] of the [`HookType::Before`] panic.
+        ///
+        /// [`catch_unwind()`]: std::panic::catch_unwind()
+        panic_info: Info,
+    },
+
+    /// [`Step`] was skipped.
+    ///
+    /// [`Step`]: gherkin::Step.
+    StepSkipped(Option<World>),
+
+    /// [`Step`] failed.
+    ///
+    /// [`Step`]: gherkin::Step.
+    StepPanicked {
+        /// [`World`] at the time [`Step`] has failed.
+        ///
+        /// [`Step`]: gherkin::Step
+        world: Option<World>,
+
+        /// [`Step`] itself.
+        ///
+        /// [`Step`]: gherkin::Step
+        step: Arc<gherkin::Step>,
+
+        /// [`Step`]s [`regex`] [`CaptureLocations`].
+        ///
+        /// [`Step`]: gherkin::Step
+        captures: Option<CaptureLocations>,
+
+        /// [`StepError`] of the [`Step`].
+        ///
+        /// [`Step`]: gherkin::Step
+        /// [`StepError`]: event::StepError
+        err: event::StepError,
+
+        /// Indicates, whether [`Step`] was background or not.
+        ///
+        /// [`Step`]: gherkin::Step
+        is_background: bool,
+    },
+}
+
+impl<W> ExecutionFailure<W> {
+    /// Takes the [`World`], leaving a [`None`] in its place.
+    fn take_world(&mut self) -> Option<W> {
+        match self {
+            Self::BeforeHookPanicked { world, .. }
+            | Self::StepSkipped(world)
+            | Self::StepPanicked { world, .. } => world.take(),
+        }
+    }
+}
 
 /// Default [`Runner`] implementation which follows [_order guarantees_][1] from
 /// the [`Runner`] trait docs.
@@ -322,7 +385,7 @@ impl<World, Which, Before, After> Basic<World, Which, Before, After> {
             &'a gherkin::Feature,
             Option<&'a gherkin::Rule>,
             &'a gherkin::Scenario,
-            Option<&'a World>,
+            Option<&'a mut World>,
         ) -> LocalBoxFuture<'a, ()>,
     {
         let Self {
@@ -401,7 +464,7 @@ where
             &'a gherkin::Feature,
             Option<&'a gherkin::Rule>,
             &'a gherkin::Scenario,
-            Option<&'a W>,
+            Option<&'a mut W>,
         ) -> LocalBoxFuture<'a, ()>
         + 'static,
 {
@@ -530,7 +593,7 @@ async fn execute<W, Before, After>(
             &'a gherkin::Feature,
             Option<&'a gherkin::Rule>,
             &'a gherkin::Scenario,
-            Option<&'a W>,
+            Option<&'a mut W>,
         ) -> LocalBoxFuture<'a, ()>,
 {
     // Those panic hook shenanigans are done to avoid console messages like
@@ -675,7 +738,7 @@ where
             &'a gherkin::Feature,
             Option<&'a gherkin::Rule>,
             &'a gherkin::Scenario,
-            Option<&'a W>,
+            Option<&'a mut W>,
         ) -> LocalBoxFuture<'a, ()>,
 {
     /// Creates a new [`Executor`].
@@ -731,28 +794,19 @@ where
                 event::Cucumber::scenario(f, r, s, e(step, captures))
             }
         };
-        let err = |e: fn(_, _, _, _) -> event::Scenario<W>| {
-            let (f, r, s) = (&feature, &rule, &scenario);
-            move |step, captures, w, info| {
-                let (f, r, s) = (Arc::clone(f), r.clone(), Arc::clone(s));
-                event::Cucumber::scenario(f, r, s, e(step, captures, w, info))
-            }
-        };
 
-        let compose = |started, passed, skipped, failed| {
-            (ok(started), ok_capt(passed), ok(skipped), err(failed))
+        let compose = |started, passed, skipped| {
+            (ok(started), ok_capt(passed), ok(skipped))
         };
         let into_bg_step_ev = compose(
             event::Scenario::background_step_started,
             event::Scenario::background_step_passed,
             event::Scenario::background_step_skipped,
-            event::Scenario::background_step_failed,
         );
         let into_step_ev = compose(
             event::Scenario::step_started,
             event::Scenario::step_passed,
             event::Scenario::step_skipped,
-            event::Scenario::step_failed,
         );
 
         self.send_event(event::Cucumber::scenario(
@@ -762,12 +816,10 @@ where
             event::Scenario::Started,
         ));
 
-        let mut is_failed = false;
-        let world: Option<Arc<W>> = async {
+        let mut result = async {
             let before_hook = self
                 .run_before_hook(&feature, rule.as_ref(), &scenario)
-                .await
-                .map_err(|_unit| None)?;
+                .await?;
 
             let feature_background = feature
                 .background
@@ -779,7 +831,8 @@ where
             let feature_background = stream::iter(feature_background)
                 .map(Ok)
                 .try_fold(before_hook, |world, bg_step| {
-                    self.run_step(world, bg_step, into_bg_step_ev).map_ok(Some)
+                    self.run_step(world, bg_step, true, into_bg_step_ev)
+                        .map_ok(Some)
                 })
                 .await?;
 
@@ -798,29 +851,52 @@ where
             let rule_background = stream::iter(rule_background)
                 .map(Ok)
                 .try_fold(feature_background, |world, bg_step| {
-                    self.run_step(world, bg_step, into_bg_step_ev).map_ok(Some)
+                    self.run_step(world, bg_step, true, into_bg_step_ev)
+                        .map_ok(Some)
                 })
                 .await?;
 
             stream::iter(scenario.steps.iter().map(|s| Arc::new(s.clone())))
                 .map(Ok)
                 .try_fold(rule_background, |world, step| {
-                    self.run_step(world, step, into_step_ev).map_ok(Some)
+                    self.run_step(world, step, false, into_step_ev).map_ok(Some)
                 })
                 .await
-                .map(|world| world.map(Arc::new))
         }
-        .inspect_err(|e| {
-            if e.is_none() {
-                is_failed = true;
-            }
-        })
-        .await
-        .unwrap_or_else(identity);
+        .await;
 
-        self.run_after_hook(world, &feature, rule.as_ref(), &scenario)
+        let world = match &mut result {
+            Ok(world) => world.take(),
+            Err(exec_err) => exec_err.take_world(),
+        };
+
+        let (world, after_hook_error) = self
+            .run_after_hook(world, &feature, rule.as_ref(), &scenario)
             .await
-            .map_or_else(|_| is_failed = true, drop);
+            .map_or_else(
+                |(w, info)| (w.map(Arc::new), Some(info)),
+                |w| (w.map(Arc::new), None),
+            );
+
+        let is_failed = result.is_err() || after_hook_error.is_some();
+
+        if let Some(exec_error) = result.err() {
+            self.emit_failed_events(
+                Arc::clone(&feature),
+                rule.clone(),
+                Arc::clone(&scenario),
+                world.clone(),
+                exec_error,
+            );
+        }
+
+        self.emit_after_hook_events(
+            Arc::clone(&feature),
+            rule.clone(),
+            Arc::clone(&scenario),
+            world,
+            after_hook_error,
+        );
 
         self.send_event(event::Cucumber::scenario(
             Arc::clone(&feature),
@@ -836,13 +912,16 @@ where
     ///
     /// # Events
     ///
-    /// - Emits [`HookType::Before`] event.
+    /// - Emits all [`HookType::Before`] events, except [`Hook::Failed`]. See
+    ///   [`Self::emit_failed_events()`] for more details.
+    ///
+    /// [`Hook::Failed`]: event::Hook::Failed
     async fn run_before_hook(
         &self,
         feature: &Arc<gherkin::Feature>,
         rule: Option<&Arc<gherkin::Rule>>,
         scenario: &Arc<gherkin::Scenario>,
-    ) -> Result<Option<W>, ()> {
+    ) -> Result<Option<W>, ExecutionFailure<W>> {
         let init_world = async {
             AssertUnwindSafe(W::new())
                 .catch_unwind()
@@ -892,81 +971,11 @@ where
                     ));
                     Ok(Some(world))
                 }
-                Err((info, world)) => {
-                    self.send_event(event::Cucumber::scenario(
-                        Arc::clone(feature),
-                        rule.map(Arc::clone),
-                        Arc::clone(scenario),
-                        event::Scenario::hook_failed(
-                            HookType::Before,
-                            world.map(Arc::new),
-                            info,
-                        ),
-                    ));
-                    Err(())
-                }
-            }
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Executes [`HookType::After`], if present.
-    ///
-    /// # Event
-    ///
-    /// - Emits [`HookType::After`] event.
-    async fn run_after_hook(
-        &self,
-        world: Option<Arc<W>>,
-        feature: &Arc<gherkin::Feature>,
-        rule: Option<&Arc<gherkin::Rule>>,
-        scenario: &Arc<gherkin::Scenario>,
-    ) -> Result<Option<Arc<W>>, ()> {
-        if let Some(hook) = self.after_hook.as_ref() {
-            self.send_event(event::Cucumber::scenario(
-                Arc::clone(feature),
-                rule.map(Arc::clone),
-                Arc::clone(scenario),
-                event::Scenario::hook_started(HookType::After),
-            ));
-
-            let fut = async {
-                let fut = (hook)(
-                    feature.as_ref(),
-                    rule.as_ref().map(AsRef::as_ref),
-                    scenario.as_ref(),
-                    world.as_ref().map(Arc::as_ref),
-                );
-                match AssertUnwindSafe(fut).catch_unwind().await {
-                    Ok(()) => Ok(world),
-                    Err(info) => Err((info, world)),
-                }
-            };
-
-            #[allow(clippy::shadow_unrelated)]
-            match fut.await {
-                Ok(world) => {
-                    self.send_event(event::Cucumber::scenario(
-                        Arc::clone(feature),
-                        rule.map(Arc::clone),
-                        Arc::clone(scenario),
-                        event::Scenario::hook_passed(HookType::After),
-                    ));
-                    Ok(world)
-                }
-                Err((info, world)) => {
-                    self.send_event(event::Cucumber::scenario(
-                        Arc::clone(feature),
-                        rule.map(Arc::clone),
-                        Arc::clone(scenario),
-                        event::Scenario::hook_failed(
-                            HookType::After,
-                            world,
-                            info.into(),
-                        ),
-                    ));
-                    Err(())
+                Err((panic_info, world)) => {
+                    Err(ExecutionFailure::BeforeHookPanicked {
+                        world,
+                        panic_info,
+                    })
                 }
             }
         } else {
@@ -978,25 +987,22 @@ where
     ///
     /// # Events
     ///
-    /// - Emits all [`Step`] events.
+    /// - Emits all [`Step`] events, except [`Step::Failed`]. See
+    ///   [`Self::emit_failed_events()`] for more details.
     ///
     /// [`Step`]: gherkin::Step
-    async fn run_step<St, Ps, Sk, F>(
+    /// [`Step::Failed`]: event::Step::Failed
+    async fn run_step<St, Ps, Sk>(
         &self,
         world: Option<W>,
         step: Arc<gherkin::Step>,
-        (started, passed, skipped, failed): (St, Ps, Sk, F),
-    ) -> Result<W, Option<Arc<W>>>
+        is_background: bool,
+        (started, passed, skipped): (St, Ps, Sk),
+    ) -> Result<W, ExecutionFailure<W>>
     where
         St: FnOnce(Arc<gherkin::Step>) -> event::Cucumber<W>,
         Ps: FnOnce(Arc<gherkin::Step>, CaptureLocations) -> event::Cucumber<W>,
         Sk: FnOnce(Arc<gherkin::Step>) -> event::Cucumber<W>,
-        F: FnOnce(
-            Arc<gherkin::Step>,
-            Option<CaptureLocations>,
-            Option<Arc<W>>,
-            event::StepError,
-        ) -> event::Cucumber<W>,
     {
         self.send_event(started(Arc::clone(&step)));
 
@@ -1050,12 +1056,151 @@ where
             }
             Ok((_, world)) => {
                 self.send_event(skipped(step));
-                Err(world.map(Arc::new))
+                Err(ExecutionFailure::StepSkipped(world))
             }
             Err((err, captures, world)) => {
-                let world = world.map(Arc::new);
-                self.send_event(failed(step, captures, world.clone(), err));
-                Err(world)
+                Err(ExecutionFailure::StepPanicked {
+                    world,
+                    step,
+                    captures,
+                    err,
+                    is_background,
+                })
+            }
+        }
+    }
+
+    /// Emits failure events of [`HookType::Before`] or [`Step`] after executing
+    /// [`Self::run_after_hook()`].
+    ///
+    /// This is done, because [`HookType::After`] requires a mutable reference
+    /// to the [`World`] while on the other hand we store immutable reference to
+    /// it inside failure events for easier debugging. So to avoid imposing
+    /// additional [`Clone`] bound on the [`World`], we run [`HookType::After`]
+    /// first without emitting any events about it's execution, then emit
+    /// failure event of [`HookType::Before`] or [`Step`], if present, and
+    /// finally emit all [`HookType::After`] events. This allows us to ensure
+    /// [order guarantees][1] while not restricting [`HookType::After`] to the
+    /// immutable reference. The only downside to this approach is that we may
+    /// emit failure events of [`HookType::Before`] or [`Step`] with [`World`]
+    /// state changed by [`HookType::After`].
+    ///
+    /// [1]: crate::Runner#order-guarantees
+    /// [`Step`]: gherkin::Step
+    fn emit_failed_events(
+        &self,
+        feature: Arc<gherkin::Feature>,
+        rule: Option<Arc<gherkin::Rule>>,
+        scenario: Arc<gherkin::Scenario>,
+        world: Option<Arc<W>>,
+        err: ExecutionFailure<W>,
+    ) {
+        match err {
+            ExecutionFailure::StepSkipped(_) => {}
+            ExecutionFailure::BeforeHookPanicked { panic_info, .. } => {
+                self.send_event(event::Cucumber::scenario(
+                    feature,
+                    rule,
+                    scenario,
+                    event::Scenario::hook_failed(
+                        HookType::Before,
+                        world,
+                        panic_info,
+                    ),
+                ));
+            }
+            ExecutionFailure::StepPanicked {
+                step,
+                captures,
+                err: error,
+                is_background: true,
+                ..
+            } => self.send_event(event::Cucumber::scenario(
+                feature,
+                rule,
+                scenario,
+                event::Scenario::background_step_failed(
+                    step, captures, world, error,
+                ),
+            )),
+            ExecutionFailure::StepPanicked {
+                step,
+                captures,
+                err: error,
+                is_background: false,
+                ..
+            } => self.send_event(event::Cucumber::scenario(
+                feature,
+                rule,
+                scenario,
+                event::Scenario::step_failed(step, captures, world, error),
+            )),
+        }
+    }
+
+    /// Executes [`HookType::After`], if present. Doesn't emit any events, see
+    /// [`Self::emit_failed_events()`] for more details.
+    async fn run_after_hook(
+        &self,
+        mut world: Option<W>,
+        feature: &Arc<gherkin::Feature>,
+        rule: Option<&Arc<gherkin::Rule>>,
+        scenario: &Arc<gherkin::Scenario>,
+    ) -> Result<Option<W>, (Option<W>, Info)> {
+        if let Some(hook) = self.after_hook.as_ref() {
+            let fut = (hook)(
+                feature.as_ref(),
+                rule.as_ref().map(AsRef::as_ref),
+                scenario.as_ref(),
+                world.as_mut(),
+            );
+            match AssertUnwindSafe(fut).catch_unwind().await {
+                Ok(()) => Ok(world),
+                Err(info) => Err((world, info.into())),
+            }
+        } else {
+            Ok(world)
+        }
+    }
+
+    /// Emits all [`HookType::After`] events. See [`Self::emit_failed_events()`]
+    /// for the explanation why we don't do that inside
+    /// [`Self::run_after_hook()`].
+    fn emit_after_hook_events(
+        &self,
+        feature: Arc<gherkin::Feature>,
+        rule: Option<Arc<gherkin::Rule>>,
+        scenario: Arc<gherkin::Scenario>,
+        world: Option<Arc<W>>,
+        err: Option<Info>,
+    ) {
+        if self.after_hook.is_some() {
+            // TODO: This `Hook::Started` event is emitted after
+            //       `HookType::After` is executed, so it can slightly mess up
+            //       timing if `timestamps` feature is enabled. Fix it by
+            //       passing here `event::Metadata` at the time
+            //       `HookType::After` was started.
+            self.send_event(event::Cucumber::scenario(
+                Arc::clone(&feature),
+                rule.clone(),
+                Arc::clone(&scenario),
+                event::Scenario::hook_started(HookType::After),
+            ));
+
+            if let Some(err) = err {
+                self.send_event(event::Cucumber::scenario(
+                    feature,
+                    rule,
+                    scenario,
+                    event::Scenario::hook_failed(HookType::After, world, err),
+                ));
+            } else {
+                self.send_event(event::Cucumber::scenario(
+                    feature,
+                    rule,
+                    scenario,
+                    event::Scenario::hook_passed(HookType::After),
+                ));
             }
         }
     }

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -110,7 +110,7 @@ pub type AfterHookFn<World> = for<'a> fn(
 type Failed = bool;
 
 /// Failure encountered during execution of [`HookType::Before`] or [`Step`].
-/// See [`Self::emit_failed_events()`] for more info.
+/// See [`Executor::emit_failed_events()`] for more info.
 ///
 /// [`Step`]: gherkin::Step
 enum ExecutionFailure<World> {

--- a/src/writer/basic.rs
+++ b/src/writer/basic.rs
@@ -383,7 +383,10 @@ impl<Out: io::Write> Basic<Out> {
                 .unwrap_or(&feat.name),
             sc.position.line,
             sc.position.col,
-            coerce_error(info),
+            format_str_with_indent(
+                coerce_error(info),
+                self.indent.saturating_sub(3) + 3
+            ),
             world
                 .map(|w| format_str_with_indent(
                     // TODO: Use "{w:#?}" syntax once MSRV bumps above 1.58.

--- a/tests/after_hook.rs
+++ b/tests/after_hook.rs
@@ -21,7 +21,7 @@ async fn main() {
             async move {
                 let before =
                     NUMBER_OF_BEFORE_WORLDS.fetch_add(1, Ordering::SeqCst);
-                assert_ne!(before, 8, "Too much before Worlds!");
+                assert_ne!(before, 8, "Too much before `World`s!");
             }
             .boxed()
         })
@@ -30,7 +30,7 @@ async fn main() {
                 if w.is_some() {
                     let after =
                         NUMBER_OF_AFTER_WORLDS.fetch_add(1, Ordering::SeqCst);
-                    assert_ne!(after, 8, "Too much after Worlds!");
+                    assert_ne!(after, 8, "Too much after `World`s!");
                 } else {
                     panic!("No World received");
                 }
@@ -75,7 +75,7 @@ impl cucumber::World for World {
         assert_ne!(
             NUMBER_OF_BEFORE_WORLDS.load(Ordering::SeqCst),
             11,
-            "Failed to initialize World",
+            "Failed to initialize `World`",
         );
 
         Ok(World(0))

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -11,9 +11,7 @@ use tempfile::NamedTempFile;
 #[then(regex = r"(\d+) secs?")]
 fn step(world: &mut World) {
     world.0 += 1;
-    if world.0 > 3 {
-        panic!("Too much!");
-    }
+    assert!(world.0 < 4, "Too much!");
 }
 
 #[tokio::main]
@@ -23,17 +21,16 @@ async fn main() {
         World::cucumber()
             .before(|_, _, sc, _| {
                 async {
-                    if sc.tags.iter().any(|t| t == "fail_before") {
-                        panic!("Tag!");
-                    }
+                    assert!(
+                        !sc.tags.iter().any(|t| t == "fail_before"),
+                        "Tag!",
+                    );
                 }
                 .boxed_local()
             })
             .after(|_, _, sc, _| {
                 async {
-                    if sc.tags.iter().any(|t| t == "fail_after") {
-                        panic!("Tag!");
-                    }
+                    assert!(!sc.tags.iter().any(|t| t == "fail_after"), "Tag!");
                 }
                 .boxed_local()
             })

--- a/tests/junit.rs
+++ b/tests/junit.rs
@@ -10,9 +10,7 @@ use tempfile::NamedTempFile;
 #[then(regex = r"(\d+) secs?")]
 fn step(world: &mut World) {
     world.0 += 1;
-    if world.0 > 3 {
-        panic!("Too much!");
-    }
+    assert!(world.0 < 4, "Too much!");
 }
 
 #[tokio::main]


### PR DESCRIPTION
Resolves #207

## Synopsis

For now `after` hook accepts mutable reference to the `World` instance, but only in case `Step` didn't fail.


## Solution

Accept shared reference to the `World` instance (it's ok because it's not passed on either way) and pass it even in case  `Step` has failed.


## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
