### PR TITLE
Notify `Writer` with the right `event::Metadata`

### DIFF
--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -1194,13 +1194,12 @@ where
     ///
     /// [`Cucumber`]: event::Cucumber
     fn send_event(&self, event: event::Cucumber<W>) {
-        // If the receiver end is dropped, then no one listens for events
+        // If the receiver end is dropped, then no one listens for events,
         // so we can just ignore it.
         drop(self.event_sender.unbounded_send(Ok(Event::new(event))));
     }
 
-    /// Notifies with the given [`Cucumber`] event with the provided
-    /// [`Metadata`].
+    /// Notifies with the given [`Cucumber`] event along with its [`Metadata`].
     ///
     /// [`Cucumber`]: event::Cucumber
     /// [`Metadata`]: event::Metadata
@@ -1209,7 +1208,7 @@ where
         event: event::Cucumber<W>,
         meta: event::Metadata,
     ) {
-        // If the receiver end is dropped, then no one listens for events
+        // If the receiver end is dropped, then no one listens for events,
         // so we can just ignore it.
         drop(self.event_sender.unbounded_send(Ok(meta.wrap(event))));
     }
@@ -1222,7 +1221,7 @@ where
         events: impl Iterator<Item = event::Cucumber<W>>,
     ) {
         for v in events {
-            // If the receiver end is dropped, then no one listens for events
+            // If the receiver end is dropped, then no one listens for events,
             // so we can just stop from here.
             if self.event_sender.unbounded_send(Ok(Event::new(v))).is_err() {
                 break;
@@ -1590,7 +1589,7 @@ enum ExecutionFailure<World> {
         /// [`StepError`]: event::StepError
         err: event::StepError,
 
-        /// [`Metadata`] at the time [`Step`] failed.
+        /// [`Metadata`] at the time when [`Step`] failed.
         ///
         /// [`Metadata`]: event::Metadata
         /// [`Step`]: gherkin::Step.


### PR DESCRIPTION
## Synopsis

For now, failures events of `Step` and `Hook`s are created at the time they are sent, not at the time of their real execution. 


## Solution

Pass right `event::Metadata`.



## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
