### PR TITLE
Fix conflicting `Id`s of CLI arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,18 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 
 
-## [0.15.1] · 2022-??-??
+## [0.15.1] · 2022-10-??
 [0.15.1]: /../../tree/v0.15.1
 
 [Diff](/../../compare/v0.15.0...v0.15.1) | [Milestone](/../../milestone/16)
 
 ### Fixed
 
-- Conflicting [`Id`][clap-arg-id]s of CLI arguments. ([#232], [#231])
+- Conflicting [`Id`][0151-1]s of CLI options. ([#232], [#231])
 
 [#231]: /../../issue/231
 [#232]: /../../pull/232
-[clap-arg-id]: https://docs.rs/clap/latest/clap/struct.Id.html
+[0151-1]: https://docs.rs/clap/latest/clap/struct.Id.html
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 
 
+## [0.15.1] · 2022-??-??
+[0.15.1]: /../../tree/v0.15.1
+
+[Diff](/../../compare/v0.15.0...v0.15.1) | [Milestone](/../../milestone/16)
+
+### Fixed
+
+- Conflicting [`Id`][clap-arg-id]s of CLI arguments. ([#232], [#231])
+
+[#231]: /../../issue/231
+[#232]: /../../pull/232
+[clap-arg-id]: https://docs.rs/clap/latest/clap/struct.Id.html
+
+
+
+
 ## [0.15.0] · 2022-10-05
 [0.15.0]: /../../tree/v0.15.0
 

--- a/book/src/output/multiple.md
+++ b/book/src/output/multiple.md
@@ -12,13 +12,13 @@ use cucumber::{writer, World as _, WriterExt as _};
 #
 # #[tokio::main]
 # async fn main() -> io::Result<()> {
-let file = fs::File::create(dbg!(format!("{}/report.json", env!("OUT_DIR"))))?;
+let file = fs::File::create(format!("{}/report.xml", env!("OUT_DIR")))?;
 World::cucumber()
     .with_writer(
         // NOTE: `Writer`s pipeline is constructed in a reversed order.
         writer::Basic::stdout() // And output to STDOUT.
             .summarized()       // Simultaneously, add execution summary.
-            .tee::<World, _>(writer::Json::for_tee(file)) // Then, output to JSON file.
+            .tee::<World, _>(writer::JUnit::for_tee(file, 0)) // Then, output to XML file.
             .normalized()       // First, normalize events order.
     )
     .run_and_exit("tests/features/book")
@@ -30,4 +30,100 @@ World::cucumber()
 
 
 
+## Merging the same `Writer`s
+
+While using [`writer::Tee`] for different `Writer`s is ok most of the time, merging the same `Writer`s isn't so obvious, because they have identical CLI arguments. Because of that you will get runtime panic from [`clap`] for using CLI arguments with the same name:
+
+```rust,should_panic
+# use std::{fs, io};
+use cucumber::{writer, World as _, WriterExt as _};
+
+# #[derive(cucumber::World, Debug, Default)]
+# struct World;
+#
+# #[tokio::main]
+# async fn main() -> io::Result<()> {
+    let file = fs::File::create(format!("{}/report.txt", env!("OUT_DIR")))?;
+    World::cucumber()
+        .with_writer(
+            writer::Basic::raw(
+                io::stdout(),
+                writer::Coloring::Auto,
+                writer::Verbosity::Default,
+            )
+                .tee::<World, _>(writer::Basic::raw(
+                    file,
+                    writer::Coloring::Never,
+                    2,
+                ))
+                .summarized()
+                .normalized(),
+        )
+        .run_and_exit("tests/features/book")
+        .await;
+# Ok(())
+# }
+```
+
+```
+thread 'main' panicked at 'Command cucumber: Argument names must be unique, but 'verbose' is in use by more than one argument or group'
+```
+
+To avoid this, you should manually construct the [`cli::Opts`] and supply it with [`Cucumber::with_cli()`]. Example below shows 2 [`writer::Basic`] outputting to `stdout` and file:
+
+```rust
+# use std::{fs, io};
+use cucumber::{cli, writer, World as _, WriterExt as _};
+
+# #[derive(cucumber::World, Debug, Default)]
+# struct World;
+#
+# #[tokio::main]
+# async fn main() -> io::Result<()> {
+    // Parse CLI arguments for a single `writer::Basic`.
+    let cli = cli::Opts::<_, _, writer::basic::Cli>::parsed();
+    let cli = cli::Opts {
+        re_filter: cli.re_filter,
+        tags_filter: cli.tags_filter,
+        parser: cli.parser,
+        runner: cli.runner,
+        // Replicate CLI arguments for every `writer::Basic`. 
+        writer: cli::Compose {
+            left: cli.writer.clone(),
+            right: cli.writer,
+        },
+        custom: cli.custom,
+    };
+    
+    let file = fs::File::create(format!("{}/report.txt", env!("OUT_DIR")))?;
+    World::cucumber()
+        .with_writer(
+            writer::Basic::raw(
+                io::stdout(),
+                writer::Coloring::Auto,
+                writer::Verbosity::Default,
+            )
+                .tee::<World, _>(writer::Basic::raw(
+                    file,
+                    writer::Coloring::Never,
+                    2,
+                ))
+                .summarized()
+                .normalized(),
+        )
+        .with_cli(cli) // Supply parsed `cli::Opts`
+        .run_and_exit("tests/features/book")
+        .await;
+# Ok(())
+# }
+```
+
+
+
+
+[`cli::Opts`]: https://docs.rs/cucumber/*/cucumber/cli/struct.Opts.html
+[`writer::Basic`]: https://docs.rs/cucumber/*/cucumber/writer/struct.Basic.html
 [`writer::Tee`]: https://docs.rs/cucumber/*/cucumber/writer/struct.Tee.html
+[`Cucumber::with_cli()`]: https://docs.rs/cucumber/*/cucumber/struct.Cucumber.html#method.with_cli
+
+[`clap`]: https://docs.rs/clap/

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,8 +93,9 @@ where
 {
     /// Regex to filter scenarios by their name.
     #[arg(
-        short = 'n',
+        id = "name",
         long = "name",
+        short = 'n',
         value_name = "regex",
         visible_alias = "scenario-name",
         global = true
@@ -106,10 +107,11 @@ where
     /// Note: Tags from Feature, Rule and Scenario are merged together on
     /// filtering, so be careful about conflicting tags on different levels.
     #[arg(
-        short = 't',
+        id = "tags",
         long = "tags",
+        short = 't',
         value_name = "tagexpr",
-        conflicts_with = "re_filter",
+        conflicts_with = "name",
         global = true
     )]
     pub tags_filter: Option<TagOperation>,

--- a/src/parser/basic.rs
+++ b/src/parser/basic.rs
@@ -33,7 +33,13 @@ use super::{Error as ParseError, Parser};
 pub struct Cli {
     /// Glob pattern to look for feature files with. By default, looks for
     /// `*.feature`s in the path configured tests runner.
-    #[arg(long = "input", short = 'i', value_name = "glob", global = true)]
+    #[arg(
+        id = "input",
+        long = "input",
+        short = 'i',
+        value_name = "glob",
+        global = true
+    )]
     pub features: Option<Walker>,
 }
 

--- a/src/writer/junit.rs
+++ b/src/writer/junit.rs
@@ -44,7 +44,7 @@ pub struct Cli {
     ///
     /// `0` is default verbosity, `1` additionally outputs world on failed
     /// steps.
-    #[arg(long = "junit-v", value_name = "0|1", global = true)]
+    #[arg(id = "junit-v", long = "junit-v", value_name = "0|1", global = true)]
     pub verbose: Option<u8>,
 }
 


### PR DESCRIPTION
Resolves #231 

## Synopsis

Currently `writer::basic::Cli` and `writer::junit::Cli` have argument with conflicting [`Id`](https://docs.rs/clap/latest/clap/struct.Id.html): `verbose`. 

## Solution

- Use the same name `#[arg(id = "...")` and `#[arg(name = "...")`, as they should be unique due to flattening.
- Document how to deal with actually overlapping CLI arguments.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
[format]: https://github.com/rust-lang/rust/issues/49359
