### PR TITLE
Add `Clone` implementations to all public types, where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 
 
+## [0.15.3] · 2022-??-??
+[0.15.3]: /../../tree/v0.15.3
+
+[Diff](/../../compare/v0.15.2...v0.15.3) | [Milestone](/../../milestone/18)
+
+### Added
+
+- `Clone` implementations to all public types, where possible ([#238])
+
+[#238]: /../../pull/238
+
+
+
+
 ## [0.15.2] · 2022-10-25
 [0.15.2]: /../../tree/v0.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 ### Added
 
-- `Clone` implementations to all public types, where possible ([#238])
+- `Clone` implementations to all public types where possible. ([#238])
 
 [#238]: /../../pull/238
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -269,7 +269,7 @@ impl Colored for Empty {}
 /// ```
 ///
 /// [`Writer`]: crate::Writer
-#[derive(Args, Debug)]
+#[derive(Args, Clone, Copy, Debug)]
 #[group(skip)]
 pub struct Compose<L: Args, R: Args> {
     /// Left [`clap::Args`] deriver.

--- a/src/cucumber.rs
+++ b/src/cucumber.rs
@@ -780,6 +780,31 @@ where
     }
 }
 
+// Manual implementation is required to omit the redundant `W: Clone` and
+// `I: Clone` trait bounds imposed by `#[derive(Clone)]`.
+impl<W, P, I, R, Wr, Cli> Clone for Cucumber<W, P, I, R, Wr, Cli>
+where
+    W: World,
+    P: Clone + Parser<I>,
+    R: Clone + Runner<W>,
+    Wr: Clone + Writer<W>,
+    Cli: Clone + clap::Args,
+    P::Cli: Clone,
+    R::Cli: Clone,
+    Wr::Cli: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            parser: self.parser.clone(),
+            runner: self.runner.clone(),
+            writer: self.writer.clone(),
+            cli: self.cli.clone(),
+            _world: PhantomData,
+            _parser_input: PhantomData,
+        }
+    }
+}
+
 impl<W, P, I, R, Wr, Cli> Debug for Cucumber<W, P, I, R, Wr, Cli>
 where
     W: World,

--- a/src/cucumber.rs
+++ b/src/cucumber.rs
@@ -780,8 +780,8 @@ where
     }
 }
 
-// Manual implementation is required to omit the redundant `W: Clone` and
-// `I: Clone` trait bounds imposed by `#[derive(Clone)]`.
+// Implemented manually to omit redundant `W: Clone` and `I: Clone` trait
+// bounds, imposed by `#[derive(Clone)]`.
 impl<W, P, I, R, Wr, Cli> Clone for Cucumber<W, P, I, R, Wr, Cli>
 where
     W: World,

--- a/src/parser/basic.rs
+++ b/src/parser/basic.rs
@@ -28,7 +28,7 @@ use crate::feature::Ext as _;
 use super::{Error as ParseError, Parser};
 
 /// CLI options of a [`Basic`] [`Parser`].
-#[derive(clap::Args, Debug)]
+#[derive(clap::Args, Clone, Debug)]
 #[group(skip)]
 pub struct Cli {
     /// Glob pattern to look for feature files with. By default, looks for

--- a/src/parser/basic.rs
+++ b/src/parser/basic.rs
@@ -164,7 +164,7 @@ impl Basic {
 }
 
 /// Error of [`gherkin`] not supporting keywords in some language.
-#[derive(Debug, Display, Error)]
+#[derive(Clone, Debug, Display, Error)]
 #[display(fmt = "Language {} isn't supported", _0)]
 pub struct UnsupportedLanguageError(
     #[error(not(source))] pub Cow<'static, str>,

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -262,7 +262,7 @@ pub type WhichScenarioFn = fn(
     &gherkin::Scenario,
 ) -> ScenarioType;
 
-/// Alias for [`Box`]ed [`Fn`] used to determine [`Scenario`]'s
+/// Alias for [`Arc`]ed [`Fn`] used to determine [`Scenario`]'s
 /// [`RetryOptions`].
 ///
 /// [`Scenario`]: gherkin::Scenario

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -390,7 +390,7 @@ impl<World, F: Clone, B: Clone, A: Clone> Clone for Basic<World, F, B, A> {
             retry_filter: self.retry_filter.clone(),
             steps: self.steps.clone(),
             which_scenario: self.which_scenario.clone(),
-            retry_options: self.retry_options.clone(),
+            retry_options: Arc::clone(&self.retry_options),
             before_hook: self.before_hook.clone(),
             after_hook: self.after_hook.clone(),
             fail_fast: self.fail_fast,

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -384,16 +384,16 @@ pub struct Basic<
 impl<World, F: Clone, B: Clone, A: Clone> Clone for Basic<World, F, B, A> {
     fn clone(&self) -> Self {
         Self {
-            max_concurrent_scenarios: self.max_concurrent_scenarios.clone(),
-            retries: self.retries.clone(),
-            retry_after: self.retry_after.clone(),
+            max_concurrent_scenarios: self.max_concurrent_scenarios,
+            retries: self.retries,
+            retry_after: self.retry_after,
             retry_filter: self.retry_filter.clone(),
             steps: self.steps.clone(),
             which_scenario: self.which_scenario.clone(),
             retry_options: self.retry_options.clone(),
             before_hook: self.before_hook.clone(),
             after_hook: self.after_hook.clone(),
-            fail_fast: self.fail_fast.clone(),
+            fail_fast: self.fail_fast,
         }
     }
 }

--- a/src/step.rs
+++ b/src/step.rs
@@ -90,6 +90,18 @@ impl<World> fmt::Debug for Collection<World> {
     }
 }
 
+// Implemented manually to omit redundant `World: Clone` trait bound, imposed by
+// `#[derive(Clone)]`.
+impl<World> Clone for Collection<World> {
+    fn clone(&self) -> Self {
+        Self {
+            given: self.given.clone(),
+            when: self.when.clone(),
+            then: self.then.clone(),
+        }
+    }
+}
+
 // Implemented manually to omit redundant `World: Default` trait bound, imposed
 // by `#[derive(Default)]`.
 impl<World> Default for Collection<World> {
@@ -223,7 +235,7 @@ impl<World> Collection<World> {
 pub type CaptureName = Option<String>;
 
 /// Context for a [`Step`] function execution.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Context {
     /// [`Step`] matched to a [`Step`] function.
     ///

--- a/src/writer/basic.rs
+++ b/src/writer/basic.rs
@@ -105,7 +105,7 @@ impl FromStr for Coloring {
 /// [`Normalized`]: writer::Normalized
 /// [`Runner`]: crate::runner::Runner
 /// [`Scenario`]: gherkin::Scenario
-#[derive(Debug, Deref, DerefMut)]
+#[derive(Clone, Debug, Deref, DerefMut)]
 pub struct Basic<Out: io::Write = io::Stdout> {
     /// [`io::Write`] implementor to write the output into.
     #[deref]

--- a/src/writer/fail_on_skipped.rs
+++ b/src/writer/fail_on_skipped.rs
@@ -26,7 +26,7 @@ use crate::{event, parser, writer, Event, World, Writer};
 /// [`Failed`]: event::Step::Failed
 /// [`Skipped`]: event::Step::Skipped
 /// [`Step`]: gherkin::Step
-#[derive(Debug, Deref)]
+#[derive(Clone, Copy, Debug, Deref)]
 pub struct FailOnSkipped<W, F = SkipFn> {
     /// Original [`Writer`] to pass transformed event into.
     #[deref]

--- a/src/writer/junit.rs
+++ b/src/writer/junit.rs
@@ -89,8 +89,8 @@ pub struct JUnit<W, Out: io::Write> {
     verbosity: Verbosity,
 }
 
-// Manual implementation is required to omit the redundant `World: Clone` trait
-// bound imposed by `#[derive(Clone)]`.
+// Implemented manually to omit redundant `World: Clone` trait bound, imposed by
+// `#[derive(Clone)]`.
 impl<World, Out: Clone + io::Write> Clone for JUnit<World, Out> {
     fn clone(&self) -> Self {
         Self {

--- a/src/writer/junit.rs
+++ b/src/writer/junit.rs
@@ -89,6 +89,21 @@ pub struct JUnit<W, Out: io::Write> {
     verbosity: Verbosity,
 }
 
+// Manual implementation is required to omit the redundant `World: Clone` trait
+// bound imposed by `#[derive(Clone)]`.
+impl<World, Out: Clone + io::Write> Clone for JUnit<World, Out> {
+    fn clone(&self) -> Self {
+        Self {
+            output: self.output.clone(),
+            report: self.report.clone(),
+            suit: self.suit.clone(),
+            scenario_started_at: self.scenario_started_at.clone(),
+            events: self.events.clone(),
+            verbosity: self.verbosity.clone(),
+        }
+    }
+}
+
 #[async_trait(?Send)]
 impl<W, Out> Writer<W> for JUnit<W, Out>
 where

--- a/src/writer/junit.rs
+++ b/src/writer/junit.rs
@@ -97,9 +97,9 @@ impl<World, Out: Clone + io::Write> Clone for JUnit<World, Out> {
             output: self.output.clone(),
             report: self.report.clone(),
             suit: self.suit.clone(),
-            scenario_started_at: self.scenario_started_at.clone(),
+            scenario_started_at: self.scenario_started_at,
             events: self.events.clone(),
-            verbosity: self.verbosity.clone(),
+            verbosity: self.verbosity,
         }
     }
 }

--- a/src/writer/libtest.rs
+++ b/src/writer/libtest.rs
@@ -167,8 +167,8 @@ pub struct Libtest<W, Out: io::Write = io::Stdout> {
     started_at: Option<SystemTime>,
 }
 
-// Manual implementation is required to omit the redundant `World: Clone` trait
-// bound imposed by `#[derive(Clone)]`.
+// Implemented manually to omit redundant `World: Clone` trait bound, imposed by
+// `#[derive(Clone)]`.
 impl<World, Out: Clone + io::Write> Clone for Libtest<World, Out> {
     fn clone(&self) -> Self {
         Self {

--- a/src/writer/libtest.rs
+++ b/src/writer/libtest.rs
@@ -174,15 +174,15 @@ impl<World, Out: Clone + io::Write> Clone for Libtest<World, Out> {
         Self {
             output: self.output.clone(),
             events: self.events.clone(),
-            parsed_all: self.parsed_all.clone(),
-            passed: self.passed.clone(),
-            failed: self.failed.clone(),
-            retried: self.retried.clone(),
-            ignored: self.ignored.clone(),
-            parsing_errors: self.parsing_errors.clone(),
-            hook_errors: self.hook_errors.clone(),
-            features_without_path: self.features_without_path.clone(),
-            started_at: self.started_at.clone(),
+            parsed_all: self.parsed_all,
+            passed: self.passed,
+            failed: self.failed,
+            retried: self.retried,
+            ignored: self.ignored,
+            parsing_errors: self.parsing_errors,
+            hook_errors: self.hook_errors,
+            features_without_path: self.features_without_path,
+            started_at: self.started_at,
         }
     }
 }

--- a/src/writer/libtest.rs
+++ b/src/writer/libtest.rs
@@ -101,7 +101,7 @@ impl FromStr for Format {
 /// [`Normalized`]: writer::Normalized
 /// [1]: https://doc.rust-lang.org/rustc/tests/index.html
 /// [2]: https://github.com/intellij-rust/intellij-rust/issues/9041
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Libtest<W, Out: io::Write = io::Stdout> {
     /// [`io::Write`] implementor to output into.
     output: Out,
@@ -165,6 +165,26 @@ pub struct Libtest<W, Out: io::Write = io::Stdout> {
     ///
     /// [`Started`]: event::Cucumber::Started
     started_at: Option<SystemTime>,
+}
+
+// Manual implementation is required to omit the redundant `World: Clone` trait
+// bound imposed by `#[derive(Clone)]`.
+impl<World, Out: Clone + io::Write> Clone for Libtest<World, Out> {
+    fn clone(&self) -> Self {
+        Self {
+            output: self.output.clone(),
+            events: self.events.clone(),
+            parsed_all: self.parsed_all.clone(),
+            passed: self.passed.clone(),
+            failed: self.failed.clone(),
+            retried: self.retried.clone(),
+            ignored: self.ignored.clone(),
+            parsing_errors: self.parsing_errors.clone(),
+            hook_errors: self.hook_errors.clone(),
+            features_without_path: self.features_without_path.clone(),
+            started_at: self.started_at.clone(),
+        }
+    }
 }
 
 #[async_trait(?Send)]

--- a/src/writer/normalize.rs
+++ b/src/writer/normalize.rs
@@ -50,6 +50,17 @@ pub struct Normalize<World, Writer> {
     queue: CucumberQueue<World>,
 }
 
+// Manual implementation is required to omit the redundant `World: Clone` trait
+// bound imposed by `#[derive(Clone)]`.
+impl<W, Writer: Clone> Clone for Normalize<W, Writer> {
+    fn clone(&self) -> Self {
+        Self {
+            writer: self.writer.clone(),
+            queue: self.queue.clone(),
+        }
+    }
+}
+
 impl<W, Writer> Normalize<W, Writer> {
     /// Creates a new [`Normalized`] wrapper, which will rearrange [`event`]s
     /// and feed them to the given [`Writer`].
@@ -216,7 +227,7 @@ impl<World, Writer> Normalized for Normalize<World, Writer> {}
 /// >                 set to `1`.
 ///
 /// [1]: crate::runner::Basic::max_concurrent_scenarios
-#[derive(Debug, Deref)]
+#[derive(Clone, Copy, Debug, Deref)]
 pub struct AssertNormalized<W: ?Sized>(W);
 
 impl<Writer> AssertNormalized<Writer> {
@@ -311,7 +322,7 @@ impl<Writer> Normalized for AssertNormalized<Writer> {}
 /// all over again with a [`next()`] item.
 ///
 /// [`next()`]: std::iter::Iterator::next()
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct Queue<K: Eq + Hash, V> {
     /// Underlying FIFO queue of values.
     queue: LinkedHashMap<K, V>,
@@ -776,6 +787,14 @@ impl<'me, World> Emitter<World> for &'me mut RulesQueue<World> {
 /// [`Scenario`]: gherkin::Scenario
 #[derive(Debug)]
 struct ScenariosQueue<World>(Vec<Event<event::RetryableScenario<World>>>);
+
+// Manual implementation is required to omit the redundant `World: Clone` trait
+// bound imposed by `#[derive(Clone)]`.
+impl<W> Clone for ScenariosQueue<W> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 
 impl<World> ScenariosQueue<World> {
     /// Creates a new [`ScenariosQueue`].

--- a/src/writer/normalize.rs
+++ b/src/writer/normalize.rs
@@ -50,9 +50,9 @@ pub struct Normalize<World, Writer> {
     queue: CucumberQueue<World>,
 }
 
-// Manual implementation is required to omit the redundant `World: Clone` trait
-// bound imposed by `#[derive(Clone)]`.
-impl<W, Writer: Clone> Clone for Normalize<W, Writer> {
+// Implemented manually to omit redundant `World: Clone` trait bound, imposed by
+// `#[derive(Clone)]`.
+impl<World, Writer: Clone> Clone for Normalize<World, Writer> {
     fn clone(&self) -> Self {
         Self {
             writer: self.writer.clone(),
@@ -788,9 +788,9 @@ impl<'me, World> Emitter<World> for &'me mut RulesQueue<World> {
 #[derive(Debug)]
 struct ScenariosQueue<World>(Vec<Event<event::RetryableScenario<World>>>);
 
-// Manual implementation is required to omit the redundant `World: Clone` trait
-// bound imposed by `#[derive(Clone)]`.
-impl<W> Clone for ScenariosQueue<W> {
+// Implemented manually to omit redundant `World: Clone` trait bound, imposed by
+// `#[derive(Clone)]`.
+impl<World> Clone for ScenariosQueue<World> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }

--- a/src/writer/out.rs
+++ b/src/writer/out.rs
@@ -18,7 +18,7 @@ use derive_more::{Deref, DerefMut, Display, From, Into};
 use super::Coloring;
 
 /// [`Style`]s for terminal output.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Styles {
     /// [`Style`] for rendering successful events.
     pub ok: Style,

--- a/src/writer/repeat.rs
+++ b/src/writer/repeat.rs
@@ -46,6 +46,18 @@ pub struct Repeat<W, Wr, F = FilterEvent<W>> {
     events: Vec<parser::Result<Event<event::Cucumber<W>>>>,
 }
 
+// Manual implementation is required to omit the redundant `World: Clone` trait
+// bound imposed by `#[derive(Clone)]`.
+impl<W, Wr: Clone, F: Clone> Clone for Repeat<W, Wr, F> {
+    fn clone(&self) -> Self {
+        Self {
+            writer: self.writer.clone(),
+            filter: self.filter.clone(),
+            events: self.events.clone(),
+        }
+    }
+}
+
 #[async_trait(?Send)]
 impl<W, Wr, F> Writer<W> for Repeat<W, Wr, F>
 where

--- a/src/writer/repeat.rs
+++ b/src/writer/repeat.rs
@@ -46,9 +46,9 @@ pub struct Repeat<W, Wr, F = FilterEvent<W>> {
     events: Vec<parser::Result<Event<event::Cucumber<W>>>>,
 }
 
-// Manual implementation is required to omit the redundant `World: Clone` trait
-// bound imposed by `#[derive(Clone)]`.
-impl<W, Wr: Clone, F: Clone> Clone for Repeat<W, Wr, F> {
+// Implemented manually to omit redundant `World: Clone` trait bound, imposed by
+// `#[derive(Clone)]`.
+impl<World, Wr: Clone, F: Clone> Clone for Repeat<World, Wr, F> {
     fn clone(&self) -> Self {
         Self {
             writer: self.writer.clone(),

--- a/src/writer/summarize.rs
+++ b/src/writer/summarize.rs
@@ -132,7 +132,7 @@ enum State {
 /// format.
 ///
 /// [`ArbitraryWriter`]: writer::Arbitrary
-#[derive(Debug, Deref)]
+#[derive(Clone, Debug, Deref)]
 pub struct Summarize<Writer> {
     /// Original [`Writer`] to summarize output of.
     #[deref]


### PR DESCRIPTION
## Synopsis

Not all types implement `Clone`. This could be useful, when we need to run `cucumber` multiple times with slightly changed config for example. 

## Solution

Add `Clone` implementations to all public types, where possible.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [ ] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
[format]: https://github.com/rust-lang/rust/issues/49359
