### PR TITLE
Fix hanging with fail-fast option (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 - Bumped up [MSRV] to 1.65 for using `let`-`else` statements.
 
+### Added
+
+- `--ff` CLI alias for `--fail-fast` CLI option.
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,14 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 ### Added
 
-- `--ff` CLI alias for `--fail-fast` CLI option.
+- `--ff` CLI alias for `--fail-fast` CLI option. ([#242])
+
+### Fixed
+
+- `--fail-fast` CLI option causing execution to hang. ([#242], [#241])
+
+[#241]: /../../issues/241
+[#242]: /../../pull/242
 
 
 
@@ -67,7 +74,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 - Conflicting [`Id`][0151-1]s of CLI options. ([#232], [#231])
 
-[#231]: /../../issue/231
+[#231]: /../../issues/231
 [#232]: /../../pull/232
 [0151-1]: https://docs.rs/clap/latest/clap/struct.Id.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ output-junit = ["dep:junit-report", "timestamps"]
 timestamps = []
 
 [dependencies]
-anyhow = { version = "1.0.58", optional = true }
 async-trait = "0.1.43"
 atty = "0.2.14"
 clap = { version = "4.0.6", features = ["derive", "wrap_help"] }
@@ -58,6 +57,7 @@ regex = "1.5.5"
 sealed = "0.4"
 
 # "macros" feature dependencies.
+anyhow = { version = "1.0.58", optional = true }
 cucumber-codegen = { version = "0.15", path = "./codegen", optional = true }
 cucumber-expressions = { version = "0.2.1", features = ["into-regex"], optional = true }
 inventory = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/cucumber-rs/cucumber"
 readme = "README.md"
 categories = ["asynchronous", "development-tools::testing"]
 keywords = ["cucumber", "testing", "bdd", "atdd", "async"]
-include = ["/src/", "/tests/after_hook.rs", "/tests/json.rs", "/tests/junit.rs", "/tests/libtest.rs", "/tests/retry.rs", "/tests/wait.rs", "/LICENSE-*", "/README.md", "/CHANGELOG.md"]
+include = ["/src/", "/tests/after_hook.rs", "/tests/fail_fast.rs", "/tests/json.rs", "/tests/junit.rs", "/tests/libtest.rs", "/tests/retry.rs", "/tests/wait.rs", "/LICENSE-*", "/README.md", "/CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -80,6 +80,10 @@ tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "sync", "ti
 
 [[test]]
 name = "after_hook"
+harness = false
+
+[[test]]
+name = "fail_fast"
 harness = false
 
 [[test]]

--- a/book/src/cli.md
+++ b/book/src/cli.md
@@ -33,6 +33,8 @@ Options:
 
       --fail-fast
           Run tests until the first failure
+          
+          [aliases: ff]
 
       --retry <int>
           Number of times a scenario will be retried in case of a failure
@@ -63,7 +65,6 @@ Options:
 
   -h, --help
           Print help information (use `-h` for a summary)
-
 ```
 
 ![record](rec/cli.gif)

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -920,7 +920,7 @@ async fn execute<W, Before, After>(
         let (runnable, sleep) =
             features.get(map_break(started_scenarios)).await;
         if run_scenarios.is_empty() && runnable.is_empty() {
-            if features.is_finished(fail_fast).await {
+            if features.is_finished(started_scenarios.is_break()).await {
                 break;
             }
 

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -57,7 +57,7 @@ pub struct Cli {
     pub concurrency: Option<usize>,
 
     /// Run tests until the first failure.
-    #[arg(long, global = true)]
+    #[arg(long, global = true, visible_alias = "ff")]
     pub fail_fast: bool,
 
     /// Number of times a scenario will be retried in case of a failure.

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -975,7 +975,7 @@ async fn execute<W, Before, After>(
                 executor.send_event(f);
             }
 
-            if fail_fast && scenario_failed {
+            if fail_fast && scenario_failed && !retried {
                 started_scenarios = ControlFlow::Break(());
             }
         }

--- a/tests/fail_fast.rs
+++ b/tests/fail_fast.rs
@@ -1,0 +1,54 @@
+use cucumber::{runner, then, writer::summarize::Stats, World as _};
+
+#[derive(Clone, Copy, cucumber::World, Debug, Default)]
+struct World;
+
+#[then(expr = "step panics")]
+fn step_panics(_: &mut World) {
+    panic!("this is a panic message");
+}
+
+#[then(expr = "nothing happens")]
+fn nothing_happens(_: &mut World) {
+    // noop
+}
+
+#[tokio::main]
+async fn main() {
+    for (feat, (p_sc, f_sc, r_sc, p_st, f_st, r_st)) in [
+        ("no_retry", (0, 1, 0, 0, 1, 0)),
+        ("retry", (0, 1, 1, 0, 1, 2)),
+        ("retry_delayed", (1, 1, 1, 1, 1, 2)),
+    ] {
+        let writer = World::cucumber()
+            .with_runner(
+                runner::Basic::default()
+                    .steps(World::collection())
+                    .max_concurrent_scenarios(1)
+                    .fail_fast(),
+            )
+            .run(format!("tests/features/fail_fast/{feat}.feature"))
+            .await;
+
+        assert_eq!(
+            writer.scenarios,
+            Stats {
+                passed: p_sc,
+                skipped: 0,
+                failed: f_sc,
+                retried: r_sc,
+            },
+            "Wrong Stats for Scenarios",
+        );
+        assert_eq!(
+            writer.steps,
+            Stats {
+                passed: p_st,
+                skipped: 0,
+                failed: f_st,
+                retried: r_st,
+            },
+            "Wrong Stats for Steps",
+        );
+    }
+}

--- a/tests/features/fail_fast/no_retry.feature
+++ b/tests/features/fail_fast/no_retry.feature
@@ -1,0 +1,6 @@
+Feature: A
+  Scenario: 1
+    Then step panics
+
+  Scenario: 2
+    Then nothing happens

--- a/tests/features/fail_fast/retry.feature
+++ b/tests/features/fail_fast/retry.feature
@@ -1,0 +1,7 @@
+Feature: A
+  @retry(2)
+  Scenario: 1
+    Then step panics
+
+  Scenario: 2
+    Then nothing happens

--- a/tests/features/fail_fast/retry_delayed.feature
+++ b/tests/features/fail_fast/retry_delayed.feature
@@ -1,0 +1,7 @@
+Feature: A
+  @retry(2).after(2s)
+  Scenario: 1
+    Then step panics
+
+  Scenario: 2
+    Then nothing happens


### PR DESCRIPTION
Fixes #241 


## Synopsis

https://github.com/cucumber-rs/cucumber/issues/241#issuecomment-1308861572


## Solution

- Consider `fail_fast` condition when evaluate `is_finished` condition.
- Detect `fail_fast` condition only when there are no retries left.
- Cover `retry` and `fail-fast` conjunction with tests. 