### PR TITLE
Fix retries with fail on skipped (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 
 
+## [0.17.1] · 2022-??-??
+[0.17.1]: /../../tree/v0.17.1
+
+[Diff](/../../compare/v0.17.0...v0.17.1) | [Milestone](/../../milestone/21)
+
+# Fixed
+
+- Not panicking on `fail_on_skipped()` with retries ([#250], [#249])
+
+[#249]: /../../issues/249
+[#250]: /../../pull/250
+
+
+
+
 ## [0.17.0] · 2022-11-23
 [0.17.0]: /../../tree/v0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 
 
-## [0.17.1] · 2022-??-??
-[0.17.1]: /../../tree/v0.17.1
+## [0.18.0] · 2022-??-??
+[0.18.0]: /../../tree/v0.18.0
 
-[Diff](/../../compare/v0.17.0...v0.17.1) | [Milestone](/../../milestone/21)
+[Diff](/../../compare/v0.17.0...v0.18.0) | [Milestone](/../../milestone/21)
 
-# Fixed
+### BC Breaks
+
+- Added `NotFound` variant to `event::StepError`. ([#250])
+
+### Fixed
 
 - Not panicking on `fail_on_skipped()` with retries ([#250], [#249])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 ### Fixed
 
-- Not panicking on `fail_on_skipped()` with retries ([#250], [#249])
+- Not panicking on `fail_on_skipped()` with retries. ([#250], [#249])
 
 [#249]: /../../issues/249
 [#250]: /../../pull/250

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,10 @@ name = "retry"
 harness = false
 
 [[test]]
+name = "retry_fail_on_skipped"
+harness = false
+
+[[test]]
 name = "wait"
 required-features = ["libtest"]
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/cucumber-rs/cucumber"
 readme = "README.md"
 categories = ["asynchronous", "development-tools::testing"]
 keywords = ["cucumber", "testing", "bdd", "atdd", "async"]
-include = ["/src/", "/tests/after_hook.rs", "/tests/fail_fast.rs", "/tests/json.rs", "/tests/junit.rs", "/tests/libtest.rs", "/tests/retry.rs", "/tests/wait.rs", "/LICENSE-*", "/README.md", "/CHANGELOG.md"]
+include = ["/src/", "/tests/after_hook.rs", "/tests/fail_fast.rs", "/tests/json.rs", "/tests/junit.rs", "/tests/libtest.rs", "/tests/retry.rs", "/tests/retry_fail_on_skipped.rs", "/tests/wait.rs", "/LICENSE-*", "/README.md", "/CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// TODO: Only because of [`derive_more`] macros, try to remove on next update.
+#![allow(clippy::use_self)]
+
 //! Key occurrences in a lifecycle of [Cucumber] execution.
 //!
 //! The top-level enum here is [`Cucumber`].
@@ -396,6 +399,16 @@ impl<World> Clone for Step<World> {
 /// [`Step`]: gherkin::Step
 #[derive(Clone, Debug, Display, Error, From)]
 pub enum StepError {
+    /// [`Step`] wasn't matched by any [`Regex`]es.
+    ///
+    /// Difference between [`Step::Skipped`] and [`StepError::NotFound`] is that
+    /// [`WriterExt::fail_on_skipped()`] is enabled.
+    ///
+    /// [`Regex`]: regex::Regex
+    /// [`WriterExt::fail_on_skipped()`]: crate::WriterExt::fail_on_skipped()
+    #[display(fmt = "Step wasn't matched by any regex")]
+    NotFound,
+
     /// [`Step`] matches multiple [`Regex`]es.
     ///
     /// [`Regex`]: regex::Regex

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// TODO: Only because of [`derive_more`] macros, try to remove on next update.
+// TODO: Only because of `derive_more` macros, try to remove on next
+//       `derive_more` upgrade.
 #![allow(clippy::use_self)]
 
 //! Key occurrences in a lifecycle of [Cucumber] execution.
@@ -399,14 +400,14 @@ impl<World> Clone for Step<World> {
 /// [`Step`]: gherkin::Step
 #[derive(Clone, Debug, Display, Error, From)]
 pub enum StepError {
-    /// [`Step`] wasn't matched by any [`Regex`]es.
+    /// [`Step`] doesn't match any [`Regex`].
     ///
-    /// Difference between [`Step::Skipped`] and [`StepError::NotFound`] is that
-    /// [`WriterExt::fail_on_skipped()`] is enabled.
+    /// It's emitted whenever a [`Step::Skipped`] event cannot be tolerated
+    /// (such as when [`fail_on_skipped()`] is used).
     ///
     /// [`Regex`]: regex::Regex
-    /// [`WriterExt::fail_on_skipped()`]: crate::WriterExt::fail_on_skipped()
-    #[display(fmt = "Step wasn't matched by any regex")]
+    /// [`fail_on_skipped()`]: crate::WriterExt::fail_on_skipped()
+    #[display(fmt = "Step doesn't match any function")]
     NotFound,
 
     /// [`Step`] matches multiple [`Regex`]es.

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -1001,7 +1001,6 @@ struct Executor<W, Before, After> {
     /// [`Step`]s [`Collection`].
     ///
     /// [`Collection`]: step::Collection
-    /// [`Step`]: step::Step
     collection: step::Collection<W>,
 
     /// Function, executed on each [`Scenario`] before running all [`Step`]s,

--- a/src/writer/basic.rs
+++ b/src/writer/basic.rs
@@ -650,7 +650,12 @@ impl<Out: io::Write> Basic<Out> {
         self.clear_last_lines_if_term_present()?;
 
         let style = |s| {
-            if retries.filter(|r| r.left > 0).is_some() {
+            if retries
+                .filter(|r| {
+                    r.left > 0 && !matches!(err, event::StepError::NotFound)
+                })
+                .is_some()
+            {
                 self.styles.bright().retry(s)
             } else {
                 self.styles.err(s)
@@ -924,7 +929,12 @@ impl<Out: io::Write> Basic<Out> {
         self.clear_last_lines_if_term_present()?;
 
         let style = |s| {
-            if retries.filter(|r| r.left > 0).is_some() {
+            if retries
+                .filter(|r| {
+                    r.left > 0 && !matches!(err, event::StepError::NotFound)
+                })
+                .is_some()
+            {
                 self.styles.bright().retry(s)
             } else {
                 self.styles.err(s)

--- a/src/writer/fail_on_skipped.rs
+++ b/src/writer/fail_on_skipped.rs
@@ -83,18 +83,16 @@ where
                 Step::Skipped
             }
         };
-        let map_failed_bg =
-            |f: Arc<_>, r: Option<_>, sc: Arc<_>, st: _, ret| {
-                let ev = map_failed(&f, &r, &sc);
-                let ev = Scenario::Background(st, ev).with_retries(ret);
-                Cucumber::scenario(f, r, sc, ev)
-            };
-        let map_failed_step =
-            |f: Arc<_>, r: Option<_>, sc: Arc<_>, st: _, ret| {
-                let ev = map_failed(&f, &r, &sc);
-                let ev = Scenario::Step(st, ev).with_retries(ret);
-                Cucumber::scenario(f, r, sc, ev)
-            };
+        let map_failed_bg = |f: Arc<_>, r: Option<_>, sc: Arc<_>, st: _| {
+            let ev = map_failed(&f, &r, &sc);
+            let ev = Scenario::Background(st, ev).with_retries(None);
+            Cucumber::scenario(f, r, sc, ev)
+        };
+        let map_failed_step = |f: Arc<_>, r: Option<_>, sc: Arc<_>, st: _| {
+            let ev = map_failed(&f, &r, &sc);
+            let ev = Scenario::Step(st, ev).with_retries(None);
+            Cucumber::scenario(f, r, sc, ev)
+        };
 
         let event = event.map(|outer| {
             outer.map(|ev| match ev {
@@ -106,21 +104,21 @@ where
                             sc,
                             RetryableScenario {
                                 event: Scenario::Background(st, Step::Skipped),
-                                retries,
+                                ..
                             },
                         ),
                     ),
-                ) => map_failed_bg(f, Some(r), sc, st, retries),
+                ) => map_failed_bg(f, Some(r), sc, st),
                 Cucumber::Feature(
                     f,
                     Feature::Scenario(
                         sc,
                         RetryableScenario {
                             event: Scenario::Background(st, Step::Skipped),
-                            retries,
+                            ..
                         },
                     ),
-                ) => map_failed_bg(f, None, sc, st, retries),
+                ) => map_failed_bg(f, None, sc, st),
                 Cucumber::Feature(
                     f,
                     Feature::Rule(
@@ -129,22 +127,22 @@ where
                             sc,
                             RetryableScenario {
                                 event: Scenario::Step(st, Step::Skipped),
-                                retries,
+                                ..
                             },
                         ),
                     ),
-                ) => map_failed_step(f, Some(r), sc, st, retries),
+                ) => map_failed_step(f, Some(r), sc, st),
                 Cucumber::Feature(
                     f,
                     Feature::Scenario(
                         sc,
                         RetryableScenario {
                             event: Scenario::Step(st, Step::Skipped),
-                            retries,
+                            ..
                         },
                         ..,
                     ),
-                ) => map_failed_step(f, None, sc, st, retries),
+                ) => map_failed_step(f, None, sc, st),
                 Cucumber::Started
                 | Cucumber::Feature(..)
                 | Cucumber::ParsingFinished { .. }

--- a/src/writer/json.rs
+++ b/src/writer/json.rs
@@ -293,6 +293,7 @@ impl<Out: io::Write> Json<Out> {
                 let status = match &err {
                     event::StepError::AmbiguousMatch(..) => Status::Ambiguous,
                     event::StepError::Panic(..) => Status::Failed,
+                    event::StepError::NotFound => Status::Undefined,
                 };
                 RunResult {
                     status,
@@ -405,10 +406,7 @@ mod status {
         /// [`event::StepError::AmbiguousMatch`].
         Ambiguous,
 
-        /// Never constructed and is here only to fully describe
-        /// [JSON schema][1].
-        ///
-        /// [1]: https://github.com/cucumber/cucumber-json-schema
+        /// [`event::Step::Failed`] with an [`event::StepError::NotFound`].
         Undefined,
 
         /// Never constructed and is here only to fully describe

--- a/src/writer/json.rs
+++ b/src/writer/json.rs
@@ -291,9 +291,9 @@ impl<Out: io::Write> Json<Out> {
             },
             event::Step::Failed(_, loc, _, err) => {
                 let status = match &err {
+                    event::StepError::NotFound => Status::Undefined,
                     event::StepError::AmbiguousMatch(..) => Status::Ambiguous,
                     event::StepError::Panic(..) => Status::Failed,
-                    event::StepError::NotFound => Status::Undefined,
                 };
                 RunResult {
                     status,

--- a/src/writer/libtest.rs
+++ b/src/writer/libtest.rs
@@ -590,7 +590,12 @@ impl<W: Debug + World, Out: io::Write> Libtest<W, Out> {
                 }
             }
             Step::Failed(_, loc, world, err) => {
-                if retries.map(|r| r.left > 0).unwrap_or_default() {
+                if retries
+                    .map(|r| {
+                        r.left > 0 && !matches!(err, event::StepError::NotFound)
+                    })
+                    .unwrap_or_default()
+                {
                     self.retried += 1;
                 } else {
                     self.failed += 1;

--- a/src/writer/summarize.rs
+++ b/src/writer/summarize.rs
@@ -369,8 +369,13 @@ impl<Writer> Summarize<Writer> {
                     .handled_scenarios
                     .insert((feature, rule, scenario), Skipped);
             }
-            Step::Failed(..) => {
-                if retries.filter(|r| r.left > 0).is_some() {
+            Step::Failed(_, _, _, err) => {
+                if retries
+                    .filter(|r| {
+                        r.left > 0 && !matches!(err, event::StepError::NotFound)
+                    })
+                    .is_some()
+                {
                     self.steps.retried += 1;
 
                     let inserted_before = self

--- a/tests/after_hook.rs
+++ b/tests/after_hook.rs
@@ -51,6 +51,7 @@ async fn main() {
 
             future::ready(()).boxed()
         })
+        .fail_on_skipped()
         .run_and_exit("tests/features/wait");
 
     let err = AssertUnwindSafe(res)
@@ -59,12 +60,12 @@ async fn main() {
         .expect_err("should err");
     let err = err.downcast_ref::<String>().unwrap();
 
-    assert_eq!(err, "2 steps failed, 1 parsing error, 4 hook errors");
+    assert_eq!(err, "4 steps failed, 1 parsing error, 8 hook errors");
     assert_eq!(NUMBER_OF_BEFORE_WORLDS.load(Ordering::SeqCst), 11);
     assert_eq!(NUMBER_OF_AFTER_WORLDS.load(Ordering::SeqCst), 11);
-    assert_eq!(NUMBER_OF_FAILED_HOOKS.load(Ordering::SeqCst), 2);
-    assert_eq!(NUMBER_OF_PASSED_STEPS.load(Ordering::SeqCst), 6);
-    assert_eq!(NUMBER_OF_SKIPPED_STEPS.load(Ordering::SeqCst), 2);
+    assert_eq!(NUMBER_OF_FAILED_HOOKS.load(Ordering::SeqCst), 4);
+    assert_eq!(NUMBER_OF_PASSED_STEPS.load(Ordering::SeqCst), 4);
+    assert_eq!(NUMBER_OF_SKIPPED_STEPS.load(Ordering::SeqCst), 4);
     assert_eq!(NUMBER_OF_FAILED_STEPS.load(Ordering::SeqCst), 2);
 }
 

--- a/tests/features/wait/nested/rule.feature
+++ b/tests/features/wait/nested/rule.feature
@@ -9,6 +9,13 @@ Feature: Basic
     Then unknown
     Then 1 sec
 
+  @allow.skipped
+  Scenario: 1 sec
+    Given 1 sec
+    When 1 sec
+    Then unknown
+    Then 1 sec
+
   Rule: rule
     @fail_before
     Scenario: 2 secs

--- a/tests/features/wait/rule.feature
+++ b/tests/features/wait/rule.feature
@@ -9,6 +9,13 @@ Feature: Basic
     Then unknown
     Then 1 sec
 
+  @allow.skipped
+  Scenario: 1 sec
+    Given 1 sec
+    When 1 sec
+    Then unknown
+    Then 1 sec
+
   Rule: rule
     @fail_before
     Scenario: 2 secs

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -35,6 +35,7 @@ async fn main() {
                 .boxed_local()
             })
             .with_writer(writer::Json::new(file.reopen().unwrap()))
+            .fail_on_skipped()
             .run("tests/features/wait")
             .await,
     );

--- a/tests/json/correct.json
+++ b/tests/json/correct.json
@@ -38,7 +38,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 1000
+              "duration": 3000
             }
           }
         ],
@@ -46,7 +46,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 10000
+              "duration": 11000
             }
           }
         ],
@@ -68,7 +68,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 33000
             }
           },
           {
@@ -77,7 +77,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 545000
+              "duration": 392000
             }
           },
           {
@@ -85,8 +85,9 @@
             "line": 9,
             "name": "unknown",
             "result": {
-              "status": "Skipped",
-              "duration": 221000
+              "status": "Undefined",
+              "duration": 182000,
+              "error_message": "Step wasn't matched by any regex"
             }
           }
         ]
@@ -110,7 +111,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 556000
+              "duration": 420000
             }
           }
         ]
@@ -135,40 +136,40 @@
         "keyword": "Scenario",
         "type": "scenario",
         "id": "basic/rule/2-secs",
-        "line": 14,
+        "line": 21,
         "name": "rule 2 secs",
         "tags": [
           {
             "name": "fail_before",
-            "line": 14
+            "line": 21
           }
         ],
         "steps": [
           {
             "keyword": "Given ",
-            "line": 15,
+            "line": 22,
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 65000
+              "duration": 48000
             }
           },
           {
             "keyword": "When ",
-            "line": 16,
+            "line": 23,
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 64000
+              "duration": 48000
             }
           },
           {
             "keyword": "Then ",
-            "line": 17,
+            "line": 24,
             "name": "2 secs",
             "result": {
               "status": "Failed",
-              "duration": 502000,
+              "duration": 450000,
               "error_message": "Matched: tests/json.rs:10:1\nStep panicked. Captured output: Too much!"
             }
           }
@@ -178,12 +179,12 @@
         "keyword": "Background",
         "type": "background",
         "id": "basic/rule/2-secs",
-        "line": 14,
+        "line": 21,
         "name": "rule 2 secs",
         "tags": [
           {
             "name": "fail_before",
-            "line": 14
+            "line": 21
           }
         ],
         "steps": [
@@ -193,7 +194,89 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 21000
+            }
+          }
+        ]
+      },
+      {
+        "after": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 2000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 6000
+            }
+          }
+        ],
+        "keyword": "Scenario",
+        "type": "scenario",
+        "id": "basic/1-sec",
+        "line": 13,
+        "name": "1 sec",
+        "tags": [
+          {
+            "name": "allow.skipped",
+            "line": 13
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 14,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 19000
+            }
+          },
+          {
+            "keyword": "When ",
+            "line": 15,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 14000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "line": 16,
+            "name": "unknown",
+            "result": {
+              "status": "Skipped",
+              "duration": 5000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Background",
+        "type": "background",
+        "id": "basic/1-sec",
+        "line": 13,
+        "name": "1 sec",
+        "tags": [
+          {
+            "name": "allow.skipped",
+            "line": 13
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 3,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 22000
             }
           }
         ]
@@ -241,7 +324,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 21000
+              "duration": 15000
             }
           },
           {
@@ -250,7 +333,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 19000
+              "duration": 16000
             }
           },
           {
@@ -258,8 +341,9 @@
             "line": 9,
             "name": "unknown",
             "result": {
-              "status": "Skipped",
-              "duration": 11000
+              "status": "Undefined",
+              "duration": 5000,
+              "error_message": "Step wasn't matched by any regex"
             }
           }
         ]
@@ -283,7 +367,7 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 28000
+              "duration": 22000
             }
           }
         ]
@@ -308,40 +392,40 @@
         "keyword": "Scenario",
         "type": "scenario",
         "id": "basic/rule/2-secs",
-        "line": 14,
+        "line": 21,
         "name": "rule 2 secs",
         "tags": [
           {
             "name": "fail_before",
-            "line": 14
+            "line": 21
           }
         ],
         "steps": [
           {
             "keyword": "Given ",
-            "line": 15,
+            "line": 22,
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 22000
+              "duration": 16000
             }
           },
           {
             "keyword": "When ",
-            "line": 16,
+            "line": 23,
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 14000
             }
           },
           {
             "keyword": "Then ",
-            "line": 17,
+            "line": 24,
             "name": "2 secs",
             "result": {
               "status": "Failed",
-              "duration": 40000,
+              "duration": 38000,
               "error_message": "Matched: tests/json.rs:10:1\nStep panicked. Captured output: Too much!"
             }
           }
@@ -351,12 +435,12 @@
         "keyword": "Background",
         "type": "background",
         "id": "basic/rule/2-secs",
-        "line": 14,
+        "line": 21,
         "name": "rule 2 secs",
         "tags": [
           {
             "name": "fail_before",
-            "line": 14
+            "line": 21
           }
         ],
         "steps": [
@@ -366,7 +450,89 @@
             "name": "1 sec",
             "result": {
               "status": "Passed",
-              "duration": 28000
+              "duration": 21000
+            }
+          }
+        ]
+      },
+      {
+        "after": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 2000
+            }
+          }
+        ],
+        "before": [
+          {
+            "result": {
+              "status": "Passed",
+              "duration": 5000
+            }
+          }
+        ],
+        "keyword": "Scenario",
+        "type": "scenario",
+        "id": "basic/1-sec",
+        "line": 13,
+        "name": "1 sec",
+        "tags": [
+          {
+            "name": "allow.skipped",
+            "line": 13
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 14,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 15000
+            }
+          },
+          {
+            "keyword": "When ",
+            "line": 15,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 18000
+            }
+          },
+          {
+            "keyword": "Then ",
+            "line": 16,
+            "name": "unknown",
+            "result": {
+              "status": "Skipped",
+              "duration": 7000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Background",
+        "type": "background",
+        "id": "basic/1-sec",
+        "line": 13,
+        "name": "1 sec",
+        "tags": [
+          {
+            "name": "allow.skipped",
+            "line": 13
+          }
+        ],
+        "steps": [
+          {
+            "keyword": "Given ",
+            "line": 3,
+            "name": "1 sec",
+            "result": {
+              "status": "Passed",
+              "duration": 22000
             }
           }
         ]
@@ -384,7 +550,7 @@
           {
             "result": {
               "status": "Failed",
-              "duration": 19000,
+              "duration": 61000,
               "error_message": "Tag!"
             }
           }
@@ -393,7 +559,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 7000
+              "duration": 6000
             }
           }
         ],
@@ -419,7 +585,7 @@
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 20000
             }
           },
           {
@@ -428,7 +594,7 @@
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 15000
             }
           },
           {
@@ -437,7 +603,7 @@
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 19000
+              "duration": 13000
             }
           }
         ]
@@ -447,7 +613,7 @@
           {
             "result": {
               "status": "Failed",
-              "duration": 17000,
+              "duration": 27000,
               "error_message": "Tag!"
             }
           }
@@ -482,7 +648,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 23000
             }
           },
           {
@@ -491,7 +657,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 15000
             }
           },
           {
@@ -500,7 +666,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 13000
             }
           }
         ]
@@ -510,7 +676,7 @@
           {
             "result": {
               "status": "Failed",
-              "duration": 17000,
+              "duration": 22000,
               "error_message": "Tag!"
             }
           }
@@ -545,7 +711,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 31000
+              "duration": 20000
             }
           },
           {
@@ -554,7 +720,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 21000
+              "duration": 14000
             }
           },
           {
@@ -563,7 +729,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 13000
             }
           }
         ]
@@ -573,7 +739,7 @@
           {
             "result": {
               "status": "Failed",
-              "duration": 17000,
+              "duration": 22000,
               "error_message": "Tag!"
             }
           }
@@ -582,7 +748,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 7000
+              "duration": 6000
             }
           }
         ],
@@ -612,7 +778,7 @@
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 20000
             }
           },
           {
@@ -621,7 +787,7 @@
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 21000
+              "duration": 17000
             }
           },
           {
@@ -630,7 +796,7 @@
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 22000
+              "duration": 14000
             }
           }
         ]
@@ -648,7 +814,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 1000
+              "duration": 2000
             }
           }
         ],
@@ -656,7 +822,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 7000
+              "duration": 6000
             }
           }
         ],
@@ -673,7 +839,7 @@
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 20000
             }
           },
           {
@@ -682,7 +848,7 @@
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 23000
+              "duration": 13000
             }
           },
           {
@@ -691,7 +857,7 @@
             "name": "2 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 13000
             }
           }
         ]
@@ -709,7 +875,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 10000
+              "duration": 5000
             }
           }
         ],
@@ -726,7 +892,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 19000
             }
           },
           {
@@ -735,7 +901,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 13000
             }
           },
           {
@@ -744,7 +910,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 19000
+              "duration": 13000
             }
           }
         ]
@@ -762,7 +928,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 6000
+              "duration": 5000
             }
           }
         ],
@@ -779,7 +945,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 20000
             }
           },
           {
@@ -788,7 +954,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 23000
+              "duration": 13000
             }
           },
           {
@@ -797,7 +963,7 @@
             "name": "1 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 12000
             }
           }
         ]
@@ -815,7 +981,7 @@
           {
             "result": {
               "status": "Passed",
-              "duration": 6000
+              "duration": 5000
             }
           }
         ],
@@ -832,7 +998,7 @@
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 27000
+              "duration": 20000
             }
           },
           {
@@ -841,7 +1007,7 @@
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 20000
+              "duration": 18000
             }
           },
           {
@@ -850,7 +1016,7 @@
             "name": "5 secs",
             "result": {
               "status": "Passed",
-              "duration": 19000
+              "duration": 13000
             }
           }
         ]

--- a/tests/json/correct.json
+++ b/tests/json/correct.json
@@ -87,7 +87,7 @@
             "result": {
               "status": "Undefined",
               "duration": 182000,
-              "error_message": "Step wasn't matched by any regex"
+              "error_message": "Step doesn't match any function"
             }
           }
         ]
@@ -343,7 +343,7 @@
             "result": {
               "status": "Undefined",
               "duration": 5000,
-              "error_message": "Step wasn't matched by any regex"
+              "error_message": "Step doesn't match any function"
             }
           }
         ]

--- a/tests/junit.rs
+++ b/tests/junit.rs
@@ -18,6 +18,7 @@ async fn main() {
     drop(
         World::cucumber()
             .with_writer(writer::JUnit::new(file.reopen().unwrap(), 1))
+            .fail_on_skipped()
             .run("tests/features/wait")
             .await,
     );

--- a/tests/junit/correct.xml
+++ b/tests/junit/correct.xml
@@ -14,7 +14,7 @@
    ✘  Then unknown
       Step failed:
       Defined: tests/features/wait/rule.feature:9:5
-      Step wasn't matched by any regex
+      Step doesn't match any function
 ]]></failure>
     </testcase>
     <testcase name="Rule: rule: Scenario: 2 secs: tests/features/wait/rule.feature:21:5" time="0.000535">
@@ -45,7 +45,7 @@
    ✘  Then unknown
       Step failed:
       Defined: tests/features/wait/nested/rule.feature:9:5
-      Step wasn't matched by any regex
+      Step doesn't match any function
 ]]></failure>
     </testcase>
     <testcase name="Rule: rule: Scenario: 2 secs: tests/features/wait/nested/rule.feature:21:5" time="0.000102">

--- a/tests/junit/correct.xml
+++ b/tests/junit/correct.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-  <testsuite id="0" name="Errors" package="testsuite/Errors" tests="1" errors="0" failures="1" hostname="localhost" timestamp="2022-03-29T07:22:01.580122Z" time="0">
+  <testsuite id="0" name="Errors" package="testsuite/Errors" tests="1" errors="0" failures="1" hostname="localhost" timestamp="2022-12-07T11:54:27.657372Z" time="0">
     <testcase name="Feature: tests/features/wait/invalid.feature" time="0">
       <failure type="Parser Error" message="Failed to parse feature: Could not parse feature file: tests/features/wait/invalid.feature"/>
     </testcase>
   </testsuite>
-  <testsuite id="1" name="Feature: Basic: tests/features/wait/rule.feature" package="testsuite/Feature: Basic: tests/features/wait/rule.feature" tests="2" errors="0" failures="1" hostname="localhost" timestamp="2022-03-29T07:22:01.574719Z" time="0.000673">
-    <testcase name="Scenario: 1 sec: tests/features/wait/rule.feature:6:3" time="0">
-      <skipped/>
+  <testsuite id="1" name="Feature: Basic: tests/features/wait/rule.feature" package="testsuite/Feature: Basic: tests/features/wait/rule.feature" tests="3" errors="0" failures="2" hostname="localhost" timestamp="2022-12-07T11:54:27.656262Z" time="0.001558">
+    <testcase name="Scenario: 1 sec: tests/features/wait/rule.feature:6:3" time="0.001023">
+      <failure type="Step Panicked" message="Step wasn&apos;t matched by any regex"><![CDATA[  Scenario: 1 sec
+   ✔> Given 1 sec
+   ✔  Given 1 sec
+   ✔  When 1 sec
+   ✘  Then unknown
+      Step failed:
+      Defined: tests/features/wait/rule.feature:9:5
+      Step wasn't matched by any regex
+]]></failure>
     </testcase>
-    <testcase name="Rule: rule: Scenario: 2 secs: tests/features/wait/rule.feature:14:5" time="0.000673">
+    <testcase name="Rule: rule: Scenario: 2 secs: tests/features/wait/rule.feature:21:5" time="0.000535">
       <failure type="Step Panicked" message="Step panicked. Captured output: Too much!"><![CDATA[  Scenario: 2 secs
    ✔> Given 1 sec
    ✔  Given 2 secs
    ✔  When 2 secs
    ✘  Then 2 secs
       Step failed:
-      Defined: tests/features/wait/rule.feature:17:7
+      Defined: tests/features/wait/rule.feature:24:7
       Matched: tests/junit.rs:9:1
       Step panicked. Captured output: Too much!
       World(
@@ -24,19 +32,30 @@
       )
 ]]></failure>
     </testcase>
-  </testsuite>
-  <testsuite id="2" name="Feature: Basic: tests/features/wait/nested/rule.feature" package="testsuite/Feature: Basic: tests/features/wait/nested/rule.feature" tests="2" errors="0" failures="1" hostname="localhost" timestamp="2022-03-29T07:22:01.576081Z" time="0.000137">
-    <testcase name="Scenario: 1 sec: tests/features/wait/nested/rule.feature:6:3" time="0">
+    <testcase name="Scenario: 1 sec: tests/features/wait/rule.feature:13:3" time="0">
       <skipped/>
     </testcase>
-    <testcase name="Rule: rule: Scenario: 2 secs: tests/features/wait/nested/rule.feature:14:5" time="0.000137">
+  </testsuite>
+  <testsuite id="2" name="Feature: Basic: tests/features/wait/nested/rule.feature" package="testsuite/Feature: Basic: tests/features/wait/nested/rule.feature" tests="3" errors="0" failures="2" hostname="localhost" timestamp="2022-12-07T11:54:27.657433Z" time="0.000175">
+    <testcase name="Scenario: 1 sec: tests/features/wait/nested/rule.feature:6:3" time="0.000073">
+      <failure type="Step Panicked" message="Step wasn&apos;t matched by any regex"><![CDATA[  Scenario: 1 sec
+   ✔> Given 1 sec
+   ✔  Given 1 sec
+   ✔  When 1 sec
+   ✘  Then unknown
+      Step failed:
+      Defined: tests/features/wait/nested/rule.feature:9:5
+      Step wasn't matched by any regex
+]]></failure>
+    </testcase>
+    <testcase name="Rule: rule: Scenario: 2 secs: tests/features/wait/nested/rule.feature:21:5" time="0.000102">
       <failure type="Step Panicked" message="Step panicked. Captured output: Too much!"><![CDATA[  Scenario: 2 secs
    ✔> Given 1 sec
    ✔  Given 2 secs
    ✔  When 2 secs
    ✘  Then 2 secs
       Step failed:
-      Defined: tests/features/wait/nested/rule.feature:17:7
+      Defined: tests/features/wait/nested/rule.feature:24:7
       Matched: tests/junit.rs:9:1
       Step panicked. Captured output: Too much!
       World(
@@ -44,30 +63,33 @@
       )
 ]]></failure>
     </testcase>
+    <testcase name="Scenario: 1 sec: tests/features/wait/nested/rule.feature:13:3" time="0">
+      <skipped/>
+    </testcase>
   </testsuite>
-  <testsuite id="3" name="Feature: Outline: tests/features/wait/outline.feature" package="testsuite/Feature: Outline: tests/features/wait/outline.feature" tests="4" errors="0" failures="0" hostname="localhost" timestamp="2022-03-29T07:22:01.576909Z" time="0.00034">
-    <testcase name="Scenario: wait: tests/features/wait/outline.feature:14:5" time="0.000085">
+  <testsuite id="3" name="Feature: Outline: tests/features/wait/outline.feature" package="testsuite/Feature: Outline: tests/features/wait/outline.feature" tests="4" errors="0" failures="0" hostname="localhost" timestamp="2022-12-07T11:54:27.658077Z" time="0.00025">
+    <testcase name="Scenario: wait: tests/features/wait/outline.feature:14:5" time="0.000066">
       <system-out><![CDATA[  Scenario Outline: wait
    ✔  Given 2 secs
    ✔  When 2 secs
    ✔  Then 2 secs
 ]]></system-out>
     </testcase>
-    <testcase name="Scenario: wait: tests/features/wait/outline.feature:15:5" time="0.000081">
+    <testcase name="Scenario: wait: tests/features/wait/outline.feature:15:5" time="0.000062">
       <system-out><![CDATA[  Scenario Outline: wait
    ✔  Given 1 secs
    ✔  When 1 secs
    ✔  Then 1 secs
 ]]></system-out>
     </testcase>
-    <testcase name="Scenario: wait: tests/features/wait/outline.feature:16:5" time="0.000093">
+    <testcase name="Scenario: wait: tests/features/wait/outline.feature:16:5" time="0.000062">
       <system-out><![CDATA[  Scenario Outline: wait
    ✔  Given 1 secs
    ✔  When 1 secs
    ✔  Then 1 secs
 ]]></system-out>
     </testcase>
-    <testcase name="Scenario: wait: tests/features/wait/outline.feature:21:5" time="0.000081">
+    <testcase name="Scenario: wait: tests/features/wait/outline.feature:21:5" time="0.00006">
       <system-out><![CDATA[  Scenario Outline: wait
    ✔  Given 5 secs
    ✔  When 5 secs
@@ -75,29 +97,29 @@
 ]]></system-out>
     </testcase>
   </testsuite>
-  <testsuite id="4" name="Feature: Rule Outline: tests/features/wait/rule_outline.feature" package="testsuite/Feature: Rule Outline: tests/features/wait/rule_outline.feature" tests="4" errors="0" failures="0" hostname="localhost" timestamp="2022-03-29T07:22:01.576911Z" time="0.000336">
-    <testcase name="Rule: To them all: Scenario: wait: tests/features/wait/rule_outline.feature:11:7" time="0.000082">
+  <testsuite id="4" name="Feature: Rule Outline: tests/features/wait/rule_outline.feature" package="testsuite/Feature: Rule Outline: tests/features/wait/rule_outline.feature" tests="4" errors="0" failures="0" hostname="localhost" timestamp="2022-12-07T11:54:27.658078Z" time="0.000257">
+    <testcase name="Rule: To them all: Scenario: wait: tests/features/wait/rule_outline.feature:11:7" time="0.000062">
       <system-out><![CDATA[  Scenario Outline: wait
    ✔  Given 2 secs
    ✔  When 2 secs
    ✔  Then 2 secs
 ]]></system-out>
     </testcase>
-    <testcase name="Rule: To them all: Scenario: wait: tests/features/wait/rule_outline.feature:12:7" time="0.000086">
+    <testcase name="Rule: To them all: Scenario: wait: tests/features/wait/rule_outline.feature:12:7" time="0.000066">
       <system-out><![CDATA[  Scenario Outline: wait
    ✔  Given 1 secs
    ✔  When 1 secs
    ✔  Then 1 secs
 ]]></system-out>
     </testcase>
-    <testcase name="Rule: To them all: Scenario: wait: tests/features/wait/rule_outline.feature:13:7" time="0.000086">
+    <testcase name="Rule: To them all: Scenario: wait: tests/features/wait/rule_outline.feature:13:7" time="0.000061">
       <system-out><![CDATA[  Scenario Outline: wait
    ✔  Given 1 secs
    ✔  When 1 secs
    ✔  Then 1 secs
 ]]></system-out>
     </testcase>
-    <testcase name="Rule: To them all: Scenario: wait: tests/features/wait/rule_outline.feature:14:7" time="0.000082">
+    <testcase name="Rule: To them all: Scenario: wait: tests/features/wait/rule_outline.feature:14:7" time="0.000068">
       <system-out><![CDATA[  Scenario Outline: wait
    ✔  Given 5 secs
    ✔  When 5 secs

--- a/tests/junit/correct.xml
+++ b/tests/junit/correct.xml
@@ -7,7 +7,7 @@
   </testsuite>
   <testsuite id="1" name="Feature: Basic: tests/features/wait/rule.feature" package="testsuite/Feature: Basic: tests/features/wait/rule.feature" tests="3" errors="0" failures="2" hostname="localhost" timestamp="2022-12-07T11:54:27.656262Z" time="0.001558">
     <testcase name="Scenario: 1 sec: tests/features/wait/rule.feature:6:3" time="0.001023">
-      <failure type="Step Panicked" message="Step wasn&apos;t matched by any regex"><![CDATA[  Scenario: 1 sec
+      <failure type="Step Panicked" message="Step doesn&apos;t match any function"><![CDATA[  Scenario: 1 sec
    ✔> Given 1 sec
    ✔  Given 1 sec
    ✔  When 1 sec
@@ -38,7 +38,7 @@
   </testsuite>
   <testsuite id="2" name="Feature: Basic: tests/features/wait/nested/rule.feature" package="testsuite/Feature: Basic: tests/features/wait/nested/rule.feature" tests="3" errors="0" failures="2" hostname="localhost" timestamp="2022-12-07T11:54:27.657433Z" time="0.000175">
     <testcase name="Scenario: 1 sec: tests/features/wait/nested/rule.feature:6:3" time="0.000073">
-      <failure type="Step Panicked" message="Step wasn&apos;t matched by any regex"><![CDATA[  Scenario: 1 sec
+      <failure type="Step Panicked" message="Step doesn&apos;t match any function"><![CDATA[  Scenario: 1 sec
    ✔> Given 1 sec
    ✔  Given 1 sec
    ✔  When 1 sec

--- a/tests/libtest.rs
+++ b/tests/libtest.rs
@@ -20,6 +20,7 @@ async fn main() {
             .with_writer(
                 writer::Libtest::new(file.reopen().unwrap()).normalized(),
             )
+            .fail_on_skipped()
             .run("tests/features/wait")
             .await,
     );

--- a/tests/libtest/correct.stdout
+++ b/tests/libtest/correct.stdout
@@ -8,7 +8,7 @@
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::6: Scenario: 1 sec::8:  When 1 sec"}
 {"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::6: Scenario: 1 sec::8:  When 1 sec"}
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::6: Scenario: 1 sec::9:  Then unknown"}
-{"type":"test","event":"failed","name":"Feature: Basic tests/features/wait/rule.feature::6: Scenario: 1 sec::9:  Then unknown","stdout":"tests/features/wait/rule.feature:9:5 (defined)\nStep wasn't matched by any regex\n"}
+{"type":"test","event":"failed","name":"Feature: Basic tests/features/wait/rule.feature::6: Scenario: 1 sec::9:  Then unknown","stdout":"tests/features/wait/rule.feature:9:5 (defined)\nStep doesn't match any function\n"}
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::19: Rule: rule::21: Scenario: 2 secs::3: Background Given 1 sec"}
 {"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::19: Rule: rule::21: Scenario: 2 secs::3: Background Given 1 sec"}
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::19: Rule: rule::21: Scenario: 2 secs::22:  Given 2 secs"}
@@ -32,7 +32,7 @@
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::8:  When 1 sec"}
 {"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::8:  When 1 sec"}
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::9:  Then unknown"}
-{"type":"test","event":"failed","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::9:  Then unknown","stdout":"tests/features/wait/nested/rule.feature:9:5 (defined)\nStep wasn't matched by any regex\n"}
+{"type":"test","event":"failed","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::9:  Then unknown","stdout":"tests/features/wait/nested/rule.feature:9:5 (defined)\nStep doesn't match any function\n"}
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::19: Rule: rule::21: Scenario: 2 secs::3: Background Given 1 sec"}
 {"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::19: Rule: rule::21: Scenario: 2 secs::3: Background Given 1 sec"}
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::19: Rule: rule::21: Scenario: 2 secs::22:  Given 2 secs"}

--- a/tests/libtest/correct.stdout
+++ b/tests/libtest/correct.stdout
@@ -1,4 +1,4 @@
-{"type":"suite","event":"started","test_count":41}
+{"type":"suite","event":"started","test_count":49}
 {"type":"test","event":"started","name":"Feature: Parsing /Users/work/Work/cucumber/tests/features/wait/invalid.feature"}
 {"type":"test","event":"failed","name":"Feature: Parsing /Users/work/Work/cucumber/tests/features/wait/invalid.feature","stdout":"Failed to parse feature: Could not parse feature file: /Users/work/Work/cucumber/tests/features/wait/invalid.feature\n"}
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::6: Scenario: 1 sec::3: Background Given 1 sec"}
@@ -8,15 +8,23 @@
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::6: Scenario: 1 sec::8:  When 1 sec"}
 {"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::6: Scenario: 1 sec::8:  When 1 sec"}
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::6: Scenario: 1 sec::9:  Then unknown"}
-{"type":"test","event":"ignored","name":"Feature: Basic tests/features/wait/rule.feature::6: Scenario: 1 sec::9:  Then unknown"}
-{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::12: Rule: rule::14: Scenario: 2 secs::3: Background Given 1 sec"}
-{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::12: Rule: rule::14: Scenario: 2 secs::3: Background Given 1 sec"}
-{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::12: Rule: rule::14: Scenario: 2 secs::15:  Given 2 secs"}
-{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::12: Rule: rule::14: Scenario: 2 secs::15:  Given 2 secs"}
-{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::12: Rule: rule::14: Scenario: 2 secs::16:  When 2 secs"}
-{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::12: Rule: rule::14: Scenario: 2 secs::16:  When 2 secs"}
-{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::12: Rule: rule::14: Scenario: 2 secs::17:  Then 2 secs"}
-{"type":"test","event":"failed","name":"Feature: Basic tests/features/wait/rule.feature::12: Rule: rule::14: Scenario: 2 secs::17:  Then 2 secs","stdout":"tests/features/wait/rule.feature:17:7 (defined)\ntests/libtest.rs:9:1 (matched)\nStep panicked. Captured output: Too much!\nWorld(\n    4,\n)\n"}
+{"type":"test","event":"failed","name":"Feature: Basic tests/features/wait/rule.feature::6: Scenario: 1 sec::9:  Then unknown","stdout":"tests/features/wait/rule.feature:9:5 (defined)\nStep wasn't matched by any regex\n"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::19: Rule: rule::21: Scenario: 2 secs::3: Background Given 1 sec"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::19: Rule: rule::21: Scenario: 2 secs::3: Background Given 1 sec"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::19: Rule: rule::21: Scenario: 2 secs::22:  Given 2 secs"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::19: Rule: rule::21: Scenario: 2 secs::22:  Given 2 secs"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::19: Rule: rule::21: Scenario: 2 secs::23:  When 2 secs"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::19: Rule: rule::21: Scenario: 2 secs::23:  When 2 secs"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::19: Rule: rule::21: Scenario: 2 secs::24:  Then 2 secs"}
+{"type":"test","event":"failed","name":"Feature: Basic tests/features/wait/rule.feature::19: Rule: rule::21: Scenario: 2 secs::24:  Then 2 secs","stdout":"tests/features/wait/rule.feature:24:7 (defined)\ntests/libtest.rs:9:1 (matched)\nStep panicked. Captured output: Too much!\nWorld(\n    4,\n)\n"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::13: Scenario: 1 sec::3: Background Given 1 sec"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::13: Scenario: 1 sec::3: Background Given 1 sec"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::13: Scenario: 1 sec::14:  Given 1 sec"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::13: Scenario: 1 sec::14:  Given 1 sec"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::13: Scenario: 1 sec::15:  When 1 sec"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/rule.feature::13: Scenario: 1 sec::15:  When 1 sec"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/rule.feature::13: Scenario: 1 sec::16:  Then unknown"}
+{"type":"test","event":"ignored","name":"Feature: Basic tests/features/wait/rule.feature::13: Scenario: 1 sec::16:  Then unknown"}
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::3: Background Given 1 sec"}
 {"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::3: Background Given 1 sec"}
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::7:  Given 1 sec"}
@@ -24,15 +32,23 @@
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::8:  When 1 sec"}
 {"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::8:  When 1 sec"}
 {"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::9:  Then unknown"}
-{"type":"test","event":"ignored","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::9:  Then unknown"}
-{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::12: Rule: rule::14: Scenario: 2 secs::3: Background Given 1 sec"}
-{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::12: Rule: rule::14: Scenario: 2 secs::3: Background Given 1 sec"}
-{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::12: Rule: rule::14: Scenario: 2 secs::15:  Given 2 secs"}
-{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::12: Rule: rule::14: Scenario: 2 secs::15:  Given 2 secs"}
-{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::12: Rule: rule::14: Scenario: 2 secs::16:  When 2 secs"}
-{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::12: Rule: rule::14: Scenario: 2 secs::16:  When 2 secs"}
-{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::12: Rule: rule::14: Scenario: 2 secs::17:  Then 2 secs"}
-{"type":"test","event":"failed","name":"Feature: Basic tests/features/wait/nested/rule.feature::12: Rule: rule::14: Scenario: 2 secs::17:  Then 2 secs","stdout":"tests/features/wait/nested/rule.feature:17:7 (defined)\ntests/libtest.rs:9:1 (matched)\nStep panicked. Captured output: Too much!\nWorld(\n    4,\n)\n"}
+{"type":"test","event":"failed","name":"Feature: Basic tests/features/wait/nested/rule.feature::6: Scenario: 1 sec::9:  Then unknown","stdout":"tests/features/wait/nested/rule.feature:9:5 (defined)\nStep wasn't matched by any regex\n"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::19: Rule: rule::21: Scenario: 2 secs::3: Background Given 1 sec"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::19: Rule: rule::21: Scenario: 2 secs::3: Background Given 1 sec"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::19: Rule: rule::21: Scenario: 2 secs::22:  Given 2 secs"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::19: Rule: rule::21: Scenario: 2 secs::22:  Given 2 secs"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::19: Rule: rule::21: Scenario: 2 secs::23:  When 2 secs"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::19: Rule: rule::21: Scenario: 2 secs::23:  When 2 secs"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::19: Rule: rule::21: Scenario: 2 secs::24:  Then 2 secs"}
+{"type":"test","event":"failed","name":"Feature: Basic tests/features/wait/nested/rule.feature::19: Rule: rule::21: Scenario: 2 secs::24:  Then 2 secs","stdout":"tests/features/wait/nested/rule.feature:24:7 (defined)\ntests/libtest.rs:9:1 (matched)\nStep panicked. Captured output: Too much!\nWorld(\n    4,\n)\n"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::13: Scenario: 1 sec::3: Background Given 1 sec"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::13: Scenario: 1 sec::3: Background Given 1 sec"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::13: Scenario: 1 sec::14:  Given 1 sec"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::13: Scenario: 1 sec::14:  Given 1 sec"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::13: Scenario: 1 sec::15:  When 1 sec"}
+{"type":"test","event":"ok","name":"Feature: Basic tests/features/wait/nested/rule.feature::13: Scenario: 1 sec::15:  When 1 sec"}
+{"type":"test","event":"started","name":"Feature: Basic tests/features/wait/nested/rule.feature::13: Scenario: 1 sec::16:  Then unknown"}
+{"type":"test","event":"ignored","name":"Feature: Basic tests/features/wait/nested/rule.feature::13: Scenario: 1 sec::16:  Then unknown"}
 {"type":"test","event":"started","name":"Feature: Outline tests/features/wait/outline.feature::14: Scenario Outline: wait::5:  Given 2 secs"}
 {"type":"test","event":"ok","name":"Feature: Outline tests/features/wait/outline.feature::14: Scenario Outline: wait::5:  Given 2 secs"}
 {"type":"test","event":"started","name":"Feature: Outline tests/features/wait/outline.feature::14: Scenario Outline: wait::6:  When 2 secs"}
@@ -81,4 +97,4 @@
 {"type":"test","event":"ok","name":"Feature: Rule Outline tests/features/wait/rule_outline.feature::3: Rule: To them all::14: Scenario Outline: wait::6:  When 5 secs"}
 {"type":"test","event":"started","name":"Feature: Rule Outline tests/features/wait/rule_outline.feature::3: Rule: To them all::14: Scenario Outline: wait::7:  Then 5 secs"}
 {"type":"test","event":"ok","name":"Feature: Rule Outline tests/features/wait/rule_outline.feature::3: Rule: To them all::14: Scenario Outline: wait::7:  Then 5 secs"}
-{"type":"suite","event":"failed","passed":36,"failed":3,"ignored":2,"measured":0,"filtered_out":0,"exec_time":0.029614}
+{"type":"suite","event":"failed","passed":42,"failed":5,"ignored":2,"measured":0,"filtered_out":0,"exec_time":0.023022}

--- a/tests/retry_fail_on_skipped.rs
+++ b/tests/retry_fail_on_skipped.rs
@@ -8,7 +8,7 @@ struct World;
 #[tokio::main]
 async fn main() {
     // We place `writer::Summarized` in a pipeline before `writer::Normalized`
-    // to check if the latter one messes up the ordering.
+    // to check whether the later one messes up the ordering.
     let res = World::cucumber()
         .with_writer(
             writer::Basic::raw(

--- a/tests/retry_fail_on_skipped.rs
+++ b/tests/retry_fail_on_skipped.rs
@@ -1,0 +1,22 @@
+use std::panic::AssertUnwindSafe;
+
+use cucumber::World as _;
+use futures::FutureExt as _;
+
+#[derive(cucumber::World, Clone, Copy, Debug, Default)]
+struct World;
+
+#[tokio::main]
+async fn main() {
+    let res = World::cucumber()
+        .fail_on_skipped()
+        .retries(1)
+        .run_and_exit("tests/features/readme/eating.feature");
+    let err = AssertUnwindSafe(res)
+        .catch_unwind()
+        .await
+        .expect_err("should err");
+    let err = err.downcast_ref::<String>().unwrap();
+
+    assert_eq!(err, "1 step failed");
+}

--- a/tests/wait.rs
+++ b/tests/wait.rs
@@ -30,6 +30,7 @@ async fn main() {
         })
         .after(move |_, _, _, _, _| time::sleep(cli.custom.pause).boxed_local())
         .with_writer(writer::Libtest::or_basic())
+        .fail_on_skipped()
         .with_cli(cli)
         .run_and_exit("tests/features/wait");
 
@@ -39,7 +40,7 @@ async fn main() {
         .expect_err("should err");
     let err = err.downcast_ref::<String>().unwrap();
 
-    assert_eq!(err, "2 steps failed, 1 parsing error");
+    assert_eq!(err, "4 steps failed, 1 parsing error");
 }
 
 #[given(regex = r"(\d+) secs?")]


### PR DESCRIPTION
## Synopsis

#249

## Solution

Don't pass info about number of retries, when transforming `Skipped` event into a `Failed`.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
[format]: https://github.com/rust-lang/rust/issues/49359
