### PR TITLE
Fix `color=always|never` CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to `cucumber` crate will be documented in this file. Th
 
 
 
+## [0.19.1] · 2022-12-??
+[0.19.1]: /../../tree/v0.19.1
+
+[Diff](/../../compare/v0.19.0...v0.19.1) | [Milestone](/../../milestone/23)
+
+### Fixed
+
+- Using autodetect for colors on `color=always|never` CLI options. ([#253])
+
+[#253]: /../../pull/253
+
+
+
+
 ## [0.19.0] · 2022-12-16
 [0.19.0]: /../../tree/v0.19.0
 

--- a/src/writer/out.rs
+++ b/src/writer/out.rs
@@ -10,7 +10,7 @@
 
 //! Tools for writing output.
 
-use std::{borrow::Cow, io, str};
+use std::{borrow::Cow, io, mem, str};
 
 use console::Style;
 use derive_more::{Deref, DerefMut, Display, From, Into};
@@ -68,11 +68,20 @@ impl Styles {
 
     /// Applies the given [`Coloring`] to these [`Styles`].
     pub fn apply_coloring(&mut self, color: Coloring) {
-        match color {
-            Coloring::Auto => {}
-            Coloring::Always => self.is_present = true,
-            Coloring::Never => self.is_present = false,
-        }
+        let is_present = match color {
+            Coloring::Always => true,
+            Coloring::Never => false,
+            Coloring::Auto => return,
+        };
+
+        let this = mem::take(self);
+        self.ok = this.ok.force_styling(is_present);
+        self.skipped = this.skipped.force_styling(is_present);
+        self.err = this.err.force_styling(is_present);
+        self.retry = this.retry.force_styling(is_present);
+        self.header = this.header.force_styling(is_present);
+        self.bold = this.bold.force_styling(is_present);
+        self.is_present = is_present;
     }
 
     /// Returns [`Styles`] with brighter colors.


### PR DESCRIPTION
## Synopsis

It happens that [`console::Style`](https://docs.rs/console/latest/console/struct.Style.html) uses autodetect for colors.

## Solution

Force colors on `color=always|never`.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
[format]: https://github.com/rust-lang/rust/issues/49359
