### PR TITLE
fix: use correct tuple key for width

### DIFF
--- a/src/writer/out.rs
+++ b/src/writer/out.rs
@@ -62,7 +62,7 @@ impl Default for Styles {
             retry: Style::new().magenta(),
             header: Style::new().blue(),
             bold: Style::new().bold(),
-            term_width: console::Term::stdout().size_checked().map(|(w, _h)| w),
+            term_width: console::Term::stdout().size_checked().map(|(_h, w)| w),
             is_present: io::stdout().is_terminal() && console::colors_enabled(),
         }
     }


### PR DESCRIPTION
Recently we have been experiencing some strange output for our cucumber tests, basically most output was removed during a run. I finally managed to find this only happens when the console height is low. I think this is because the tuple keys are flipped in the changed bit. According to the [docs](https://docs.rs/console/0.15.7/src/console/term.rs.html#386) the `size_checked` returns rows (height) and columns (width)...