### PR TITLE
Allow configure `fmt::Layer` better (#353)

### DIFF
--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -38,15 +38,16 @@ where
     Wr: Writer<W>,
     Cli: clap::Args,
 {
-    /// Initializes a global [`tracing::Subscriber`] with a default
-    /// [`fmt::Layer`] and [`LevelFilter::INFO`].
+    /// Initializes a global [`tracing::Subscriber`] for this [`Cucumber`] with
+    /// a default [`fmt::Layer`] and [`LevelFilter::INFO`].
     ///
     /// [`fmt::Layer`]: tracing_subscriber::fmt::Layer
     #[must_use]
     pub fn init_tracing(self) -> Self {
         self.configure_and_init_tracing(
-            format::DefaultFields::new(),
-            Format::default(),
+            tracing_subscriber::fmt::layer()
+                .fmt_fields(format::DefaultFields::new())
+                .event_format(Format::default()),
             |layer| {
                 tracing_subscriber::registry()
                     .with(LevelFilter::INFO.and_then(layer))
@@ -54,8 +55,9 @@ where
         )
     }
 
-    /// Configures a [`fmt::Layer`], additionally wraps it (for example, into a
-    /// [`LevelFilter`]), and initializes as a global [`tracing::Subscriber`].
+    /// Configures the provided [`fmt::Layer`] for this [`Cucumber`] and allows
+    /// to additionally wrap it (for example, into a [`LevelFilter`]) before
+    /// initializing it as a global [`tracing::Subscriber`].
     ///
     /// # Example
     ///
@@ -63,7 +65,7 @@ where
     /// # use cucumber::{Cucumber, World as _};
     /// # use tracing_subscriber::{
     /// #     filter::LevelFilter,
-    /// #     fmt::format::{self, Format},
+    /// #     fmt::{self, format::{self, Format}},
     /// #     layer::SubscriberExt,
     /// #     Layer,
     /// # };
@@ -74,11 +76,12 @@ where
     /// # let _ = async {
     /// World::cucumber()
     ///     .configure_and_init_tracing(
-    ///         format::DefaultFields::new(),
-    ///         Format::default(),
-    ///         |fmt_layer| {
+    ///         fmt::layer()
+    ///             .fmt_fields(format::DefaultFields::new())
+    ///             .event_format(Format::default()),
+    ///         |layer| {
     ///             tracing_subscriber::registry()
-    ///                 .with(LevelFilter::INFO.and_then(fmt_layer))
+    ///                 .with(LevelFilter::INFO.and_then(layer))
     ///         },
     ///     )
     ///     .run_and_exit("./tests/features/doctests.feature")
@@ -90,8 +93,7 @@ where
     #[must_use]
     pub fn configure_and_init_tracing<Event, Fields, Sub, Conf, Out>(
         self,
-        fmt_fields: Fields,
-        event_format: Event,
+        fmt_layer: tracing_subscriber::fmt::Layer<Sub, Fields, Event>,
         configure: Conf,
     ) -> Self
     where
@@ -118,9 +120,9 @@ where
         let (span_close_sender, span_close_receiver) = mpsc::unbounded();
 
         let layer = RecordScenarioId::new(span_close_sender).and_then(
-            tracing_subscriber::fmt::layer()
-                .fmt_fields(SkipScenarioIdSpan(fmt_fields))
-                .event_format(AppendScenarioMsg(event_format))
+            fmt_layer
+                .map_fmt_fields(SkipScenarioIdSpan)
+                .map_event_format(AppendScenarioMsg)
                 .with_writer(CollectorWriter::new(logs_sender)),
         );
         Dispatch::new(configure(layer)).init();

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -6,7 +6,10 @@ use regex::RegexBuilder;
 use tempfile::NamedTempFile;
 use tracing_subscriber::{
     filter::LevelFilter,
-    fmt::format::{DefaultFields, Format},
+    fmt::{
+        self,
+        format::{DefaultFields, Format},
+    },
     layer::SubscriberExt as _,
     Layer as _,
 };
@@ -48,8 +51,9 @@ async fn test() {
             .fail_on_skipped()
             .with_default_cli()
             .configure_and_init_tracing(
-                DefaultFields::new(),
-                Format::default().with_ansi(false).without_time(),
+                fmt::layer().fmt_fields(DefaultFields::new()).event_format(
+                    Format::default().with_ansi(false).without_time(),
+                ),
                 |layer| {
                     tracing_subscriber::registry()
                         .with(LevelFilter::INFO.and_then(layer))

--- a/tests/junit.rs
+++ b/tests/junit.rs
@@ -6,7 +6,10 @@ use regex::RegexBuilder;
 use tempfile::NamedTempFile;
 use tracing_subscriber::{
     filter::LevelFilter,
-    fmt::format::{DefaultFields, Format},
+    fmt::{
+        self,
+        format::{DefaultFields, Format},
+    },
     layer::SubscriberExt as _,
     Layer as _,
 };
@@ -35,8 +38,9 @@ async fn output() {
             .fail_on_skipped()
             .with_default_cli()
             .configure_and_init_tracing(
-                DefaultFields::new(),
-                Format::default().with_ansi(false).without_time(),
+                fmt::layer().fmt_fields(DefaultFields::new()).event_format(
+                    Format::default().with_ansi(false).without_time(),
+                ),
                 |layer| {
                     tracing_subscriber::registry()
                         .with(LevelFilter::INFO.and_then(layer))

--- a/tests/tracing.rs
+++ b/tests/tracing.rs
@@ -7,7 +7,10 @@ use regex::Regex;
 use tokio::{spawn, time};
 use tracing_subscriber::{
     filter::LevelFilter,
-    fmt::format::{DefaultFields, Format},
+    fmt::{
+        self,
+        format::{DefaultFields, Format},
+    },
     layer::SubscriberExt as _,
     Layer,
 };
@@ -38,8 +41,9 @@ async fn main() {
         .fail_on_skipped()
         .with_default_cli()
         .configure_and_init_tracing(
-            DefaultFields::new(),
-            Format::default().with_ansi(false).without_time(),
+            fmt::layer().fmt_fields(DefaultFields::new()).event_format(
+                Format::default().with_ansi(false).without_time(),
+            ),
             |layer| {
                 tracing_subscriber::registry()
                     .with(LevelFilter::INFO.and_then(layer))


### PR DESCRIPTION
Resolves #353


## Synopsis

See https://github.com/cucumber-rs/cucumber/issues/353#issue-2770975250 and https://github.com/cucumber-rs/cucumber/issues/353#issuecomment-2602575639 for details:

> I'd like to set `.with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)` on the `tracing` `Layer` when running Cucumber, but there is no API for it. I have tried plenty of workarounds, but I always get duplicated, unordered or missing logs. Could you please provide an API for customizing your `tracing` `Layer`?

> actually, the struct `Layered` [implements the `Layer` trait](https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/layer/struct.Layered.html#impl-Layer%3CS%3E-for-Layered%3CA,+B,+S%3E). However, you're referring to the [`fmt::Layer` struct and its method](https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/fmt/struct.Layer.html#method.with_span_events), not the `Layer` trait. I see... and you want to access [the initialized `fmt::layer()`](https://docs.rs/cucumber/0.21.1/src/cucumber/tracing.rs.html#121-124) directly to tweak it. [`Layered::downcast_ref()`](https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/layer/struct.Layered.html#method.downcast_ref) won't be much help here too, because the required methods have the `self` receiver, and we don't have `Layered::downcast_mut()` to `mem::swap()` it in any way too.

So, the current [`Cucumber::configure_and_init_tracing()`](https://docs.rs/cucumber/0.21.1/cucumber/struct.Cucumber.html#method.configure_and_init_tracing) API is quite limiting regarding the initialized `fmt::Layer` in the way that allows only specifying its [`.fmt_fields()`](https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/fmt/struct.Layer.html#method.fmt_fields) and [`.event_format()`](https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/fmt/struct.Layer.html#method.event_format) directly.



## Solution

Instead of accepting only `.fmt_fields()` and `.event_format()` in `Cucumber::configure_and_init_tracing()`, let's accept the whole `fmt::Layer` struct and reconfigure it before passing to the closure. 

This doesn't make the API surface harder, since the following code
```rust
        World::cucumber()
            .configure_and_init_tracing(
                DefaultFields::new(),
                Format::default().with_ansi(false).without_time(),
                |layer| {
                    tracing_subscriber::registry()
                        .with(LevelFilter::INFO.and_then(layer))
                },
            )
```
becomes
```rust
        World::cucumber()
            .configure_and_init_tracing(
                fmt::layer().fmt_fields(DefaultFields::new()).event_format(
                    Format::default().with_ansi(false).without_time(),
                ),
                |layer| {
                    tracing_subscriber::registry()
                        .with(LevelFilter::INFO.and_then(layer))
                },
            )
```
but allows tweaking the `fmt::layer()` much more.



## Checklist

- [x] Tests are updated
- [ ] Documentation is updated
- [ ] CHANGELOG entry is added