### PR TITLE
#366 Add documentation warning about calling .after multiple times

### DIFF
--- a/book/src/writing/hooks.md
+++ b/book/src/writing/hooks.md
@@ -38,7 +38,8 @@ World::cucumber()
 > __WARNING__: __Think twice before using [`Before` hook]!__  
 > Whatever happens in a [`Before` hook] is invisible to people reading `.feature`s. You should consider using a [`Background`] keyword as a more explicit alternative, especially if the setup should be readable by non-technical people. Only use a [`Before` hook] for low-level logic such as starting a browser or deleting data from a database.
 
-
+> __WARNING__: __Only one [`Before` hook] can be registered!__
+> Only one [`Before` hook] can be be registered, if multiple `.before` calls are made only the last one will be run.
 
 
 ## `After` hook
@@ -72,7 +73,8 @@ World::cucumber()
 
 > __TIP__: [`After` hook] receives an [`event::ScenarioFinished`] as one of its arguments, which indicates why the [scenario] has finished (passed, failed or skipped). This information, for example, may be used to decide whether some external resources (like files) should be cleaned up if the [scenario] passes, or leaved "as is" if it fails, so helping to "freeze" the failure conditions for better investigation. 
 
-
+> __WARNING__: __Only one [`After` hook] can be registered!__
+> Only one [`After` hook] can be be registered, if multiple `.after` calls are made only the last one will be run.
 
 
 [`After` hook]: https://cucumber.io/docs/cucumber/api#after

--- a/src/cucumber.rs
+++ b/src/cucumber.rs
@@ -1015,6 +1015,9 @@ where
     /// Sets a hook, executed on each [`Scenario`] before running all its
     /// [`Step`]s, including [`Background`] ones.
     ///
+    /// Note: Only one [`Before` hook] can be be registered, if multiple
+    /// `.before` calls are made only the last one will be run.
+    ///
     /// [`Background`]: gherkin::Background
     /// [`Scenario`]: gherkin::Scenario
     /// [`Step`]: gherkin::Step
@@ -1045,6 +1048,9 @@ where
 
     /// Sets a hook, executed on each [`Scenario`] after running all its
     /// [`Step`]s, even after [`Skipped`] of [`Failed`] [`Step`]s.
+    ///
+    /// Note: Only one [`After` hook] can be be registered, if multiple
+    /// `.after` calls are made only the last one will be run.
     ///
     /// Last `World` argument is supplied to the function, in case it was
     /// initialized before by running [`before`] hook or any [`Step`].

--- a/src/runner/basic.rs
+++ b/src/runner/basic.rs
@@ -577,6 +577,9 @@ impl<World, Which, Before, After> Basic<World, Which, Before, After> {
     /// Sets a hook, executed on each [`Scenario`] before running all its
     /// [`Step`]s, including [`Background`] ones.
     ///
+    /// Note: Only one [`Before` hook] can be be registered, if multiple
+    /// `.before` calls are made only the last one will be run.
+    ///
     /// [`Background`]: gherkin::Background
     /// [`Scenario`]: gherkin::Scenario
     /// [`Step`]: gherkin::Step
@@ -622,6 +625,9 @@ impl<World, Which, Before, After> Basic<World, Which, Before, After> {
 
     /// Sets hook, executed on each [`Scenario`] after running all its
     /// [`Step`]s, even after [`Skipped`] of [`Failed`] ones.
+    ///
+    /// Note: Only one [`After` hook] can be be registered, if multiple
+    /// `.after` calls are made only the last one will be run.
     ///
     /// Last `World` argument is supplied to the function, in case it was
     /// initialized before by running [`before`] hook or any [`Step`].


### PR DESCRIPTION
Problem: It wasn't clear that `.after` and `.before` calls should only be called once. 

Solution: Add notes to both the book and rust docs.

This PR fixes #366. 