### PR TITLE
[deps] upgrade `clap` for CI.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ timestamps = []
 tracing = ["dep:crossbeam-utils", "dep:tracing", "dep:tracing-subscriber"]
 
 [dependencies]
-clap = { version = "4.3.2", features = ["derive", "wrap_help"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 console = "0.16"
 derive_more = { version = "2.0", features = ["as_ref", "debug", "deref", "deref_mut", "display", "error", "from", "from_str", "into"] }
 either = "1.6"


### PR DESCRIPTION
Seems like the build failures may be caused by an old line in a sub-dependency of `clap`. This *should?* help.